### PR TITLE
feat: ローカル文字起こしCLIコマンドの追加

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -12,7 +12,9 @@
       "Bash(git commit:*)",
       "Bash(chmod:*)",
       "Bash(cat:*)",
-      "Bash(gcloud logging read:*)"
+      "Bash(gcloud logging read:*)",
+      "Bash(git push:*)",
+      "Bash(gh pr create:*)"
     ],
     "deny": [],
     "ask": []

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ node_modules/
 
 # Deno cache
 .deno/
+
+transcripts

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,22 @@ logs:
 	@echo "📜 Recent logs:"
 	@gcloud logging read "resource.type=cloud_run_revision AND resource.labels.service_name=scribe-bot" --limit 50 --format json | jq -r '.[] | "\(.timestamp): \(.textPayload // .jsonPayload.message)"'
 
+# Local transcription
+transcribe:
+	@if [ -z "$(FILE)" ]; then \
+		echo "Error: FILE parameter is required"; \
+		echo "Usage: make transcribe FILE=path/to/audio.mp3 [ARGS='--option value']"; \
+		echo ""; \
+		echo "Examples:"; \
+		echo "  make transcribe FILE=audio.mp3"; \
+		echo "  make transcribe FILE=video.mp4 ARGS='--output transcript.txt'"; \
+		echo "  make transcribe FILE=meeting.m4a ARGS='--speaker-names \"Alice,Bob\"'"; \
+		echo "  make transcribe FILE=audio.wav ARGS='--no-diarize --format json'"; \
+		exit 1; \
+	fi
+	@echo "🎙️ Transcribing file: $(FILE)"
+	@deno run --allow-all src/cli.ts $(FILE) $(ARGS)
+
 # Help
 help:
 	@echo "Available commands:"
@@ -56,4 +72,6 @@ help:
 	@echo "  make status      - Show Cloud Run deployment status"
 	@echo "  make env         - Show current environment variables"
 	@echo "  make logs        - Show recent Cloud Run logs"
+	@echo "  make transcribe  - Transcribe audio/video files locally"
+	@echo "                     Usage: make transcribe FILE=path/to/file [ARGS='options']"
 	@echo "  make help        - Show this help message"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,232 @@
+#!/usr/bin/env -S deno run --allow-all
+
+import "https://deno.land/std@0.224.0/dotenv/load.ts";
+import { transcribeFile } from "./transcribe-core.ts";
+import { TranscriptionOptions } from "./types.ts";
+import { createTranscriptionHeader } from "./utils.ts";
+
+interface CliOptions extends TranscriptionOptions {
+  output?: string;
+  format: "text" | "json";
+  noSave?: boolean;
+}
+
+/**
+ * Parse command line arguments
+ */
+function parseArgs(): { filePath: string; options: CliOptions } {
+  const args = Deno.args;
+  
+  // Show help if no arguments or help flag
+  if (args.length === 0 || args.includes("--help") || args.includes("-h")) {
+    printHelp();
+    Deno.exit(0);
+  }
+
+  // Find the file path (first non-flag argument)
+  const filePath = args.find((arg) => !arg.startsWith("-")) || "";
+  if (!filePath) {
+    console.error("Error: File path is required");
+    printHelp();
+    Deno.exit(1);
+  }
+
+  // Parse options
+  const options: CliOptions = {
+    diarize: !args.includes("--no-diarize"),
+    showTimestamp: !args.includes("--no-timestamp"),
+    tagAudioEvents: !args.includes("--no-audio-events"),
+    format: "text",
+    noSave: args.includes("--no-save"),
+  };
+
+  // Parse speaker count
+  const speakerIndex = args.indexOf("--num-speakers");
+  if (speakerIndex !== -1 && args[speakerIndex + 1]) {
+    const num = parseInt(args[speakerIndex + 1], 10);
+    if (!isNaN(num) && num > 0) {
+      options.numSpeakers = num;
+    }
+  }
+
+  // Parse speaker names
+  const speakerNamesIndex = args.indexOf("--speaker-names");
+  if (speakerNamesIndex !== -1 && args[speakerNamesIndex + 1]) {
+    options.speakerNames = args[speakerNamesIndex + 1]
+      .split(",")
+      .map(s => s.trim())
+      .filter(s => s.length > 0);
+  }
+
+  // Parse output file
+  const outputIndex = args.indexOf("--output");
+  const outputShortIndex = args.indexOf("-o");
+  const outIndex = outputIndex !== -1 ? outputIndex : outputShortIndex;
+  if (outIndex !== -1 && args[outIndex + 1]) {
+    options.output = args[outIndex + 1];
+  }
+
+  // Parse format
+  const formatIndex = args.indexOf("--format");
+  const formatShortIndex = args.indexOf("-f");
+  const fmtIndex = formatIndex !== -1 ? formatIndex : formatShortIndex;
+  if (fmtIndex !== -1 && args[fmtIndex + 1]) {
+    const format = args[fmtIndex + 1].toLowerCase();
+    if (format === "json" || format === "text") {
+      options.format = format;
+    }
+  }
+
+  return { filePath, options };
+}
+
+/**
+ * Print help message
+ */
+function printHelp(): void {
+  console.log(`
+ElevenLabs Transcription CLI
+
+Usage: deno run --allow-all src/cli.ts [options] <file>
+
+Arguments:
+  <file>                Path to audio or video file to transcribe
+
+Options:
+  -h, --help           Show this help message
+  -o, --output <file>  Output file path (default: transcripts/<filename>_<timestamp>.txt)
+  -f, --format <type>  Output format: text or json (default: text)
+  --no-save            Output to stdout instead of saving to file
+  
+Transcription Options:
+  --no-diarize         Disable speaker identification (default: enabled)
+  --num-speakers <n>   Number of speakers (default: auto-detect)
+  --speaker-names <names>  Comma-separated speaker names
+                           Example: --speaker-names "Alice,Bob,Charlie"
+  --no-timestamp       Disable timestamps in output
+  --no-audio-events    Disable audio event tagging
+
+Examples:
+  # Basic transcription to stdout
+  deno run --allow-all src/cli.ts audio.mp3
+
+  # Save to file with speaker names
+  deno run --allow-all src/cli.ts -o transcript.txt --speaker-names "Alice,Bob" meeting.mp4
+
+  # JSON output without timestamps
+  deno run --allow-all src/cli.ts -f json --no-timestamp audio.m4a
+
+  # Disable speaker diarization
+  deno run --allow-all src/cli.ts --no-diarize recording.wav
+
+Note: Video files (mp4, mkv, mov, etc.) will be automatically converted to audio before transcription.
+`);
+}
+
+/**
+ * Main function
+ */
+async function main() {
+  try {
+    const { filePath, options } = parseArgs();
+
+    // Check if file exists
+    try {
+      await Deno.stat(filePath);
+    } catch {
+      console.error(`Error: File not found: ${filePath}`);
+      Deno.exit(1);
+    }
+
+    // Debug: Check if API key is loaded
+    const apiKey = Deno.env.get("ELEVENLABS_API_KEY");
+    if (!apiKey) {
+      console.error("Error: ELEVENLABS_API_KEY not found in environment variables");
+      console.error("Please ensure .env file exists and contains ELEVENLABS_API_KEY");
+      Deno.exit(1);
+    }
+    console.log(`API Key loaded: ${apiKey.substring(0, 10)}...`);
+
+    console.log(`Transcribing: ${filePath}`);
+    console.log("Options:", {
+      diarize: options.diarize,
+      numSpeakers: options.numSpeakers,
+      speakerNames: options.speakerNames,
+      showTimestamp: options.showTimestamp,
+      tagAudioEvents: options.tagAudioEvents,
+      format: options.format,
+    });
+
+    // Perform transcription
+    const result = await transcribeFile(filePath, options);
+
+    if (!result.transcript) {
+      console.error("Error: No transcript was generated");
+      Deno.exit(1);
+    }
+
+    // Add filename header to transcript
+    const filename = filePath.split("/").pop() || filePath;
+    const finalTranscript = createTranscriptionHeader(filename) + result.transcript;
+
+    // Determine output path
+    let outputPath = options.output;
+    
+    // If no output specified and not --no-save, create default output path
+    if (!outputPath && !options.noSave) {
+      // Create transcripts directory if it doesn't exist
+      const transcriptsDir = "transcripts";
+      try {
+        await Deno.mkdir(transcriptsDir, { recursive: true });
+      } catch {
+        // Directory might already exist
+      }
+      
+      // Generate timestamp for filename
+      const timestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, -5);
+      const baseFilename = filename.replace(/\.[^/.]+$/, ""); // Remove extension
+      const extension = options.format === "json" ? "json" : "txt";
+      outputPath = `${transcriptsDir}/${baseFilename}_${timestamp}.${extension}`;
+    }
+
+    // Output result
+    if (options.format === "json") {
+      const jsonOutput = {
+        file: filename,
+        transcript: finalTranscript,
+        languageCode: result.languageCode,
+        ...(result.words ? { words: result.words } : {}),
+      };
+      
+      const jsonString = JSON.stringify(jsonOutput, null, 2);
+      
+      if (outputPath) {
+        await Deno.writeTextFile(outputPath, jsonString);
+        console.log(`\nTranscription saved to: ${outputPath}`);
+      } else {
+        console.log(jsonString);
+      }
+    } else {
+      // Text format
+      if (outputPath) {
+        await Deno.writeTextFile(outputPath, finalTranscript);
+        console.log(`\nTranscription saved to: ${outputPath}`);
+      } else {
+        console.log("\n" + finalTranscript);
+      }
+    }
+
+    console.log("\nTranscription completed successfully!");
+  } catch (error) {
+    console.error("Error during transcription:", error instanceof Error ? error.message : error);
+    if (error instanceof Error && error.stack) {
+      console.error("Stack trace:", error.stack);
+    }
+    Deno.exit(1);
+  }
+}
+
+// Run main function
+if (import.meta.main) {
+  main();
+}

--- a/src/deno.lock
+++ b/src/deno.lock
@@ -536,5 +536,11 @@
       ],
       "bin": true
     }
+  },
+  "remote": {
+    "https://deno.land/std@0.224.0/dotenv/load.ts": "587b342f0f6a3df071331fe6ba1c823729ab68f7d53805809475e486dd4161d7",
+    "https://deno.land/std@0.224.0/dotenv/mod.ts": "0180eaeedaaf88647318811cdaa418cc64dc51fb08354f91f5f480d0a1309f7d",
+    "https://deno.land/std@0.224.0/dotenv/parse.ts": "09977ff88dfd1f24f9973a338f0f91bbdb9307eb5ff6085446e7c423e4c7ba0c",
+    "https://deno.land/std@0.224.0/dotenv/stringify.ts": "275da322c409170160440836342eaa7cf012a1d11a7e700d8ca4e7f2f8aa4615"
   }
 }

--- a/src/scribe.ts
+++ b/src/scribe.ts
@@ -1,14 +1,9 @@
-import { ElevenLabsClient } from "npm:elevenlabs@1.59.0";
 import {
   TranscriptionOptions,
-  WordItem,
   TranscriptionLog
 } from "./types.ts";
 import {
   getFileExtensionFromMime,
-  formatTimestamp,
-  extractSentences,
-  groupBySpeaker,
   createTranscriptionHeader,
   convertVideoToAudio,
   isVideoFile,
@@ -22,12 +17,7 @@ import {
   sendDiscordMessage,
   uploadTranscriptToDiscord,
 } from "./discord.ts";
-import { config } from "./config.ts";
-import { identifySpeakers, replaceSpeakerLabels } from "./openai-client.ts";
-
-const elevenlabs = new ElevenLabsClient({
-  apiKey: config.elevenLabsApiKey,
-});
+import { transcribeCore } from "./transcribe-core.ts";
 
 
 export async function transcribeAudioFile({
@@ -111,77 +101,21 @@ export async function transcribeAudioFile({
       // Discord warnings are handled in discord-handler.ts
     }
 
-    console.log("calling elevenlabs with options:", options);
+    console.log("calling transcribe-core with options:", options);
 
-    // Read file into memory only if it's small enough
-    // For large files, we need a different approach
-    const file = await Deno.open(tempFilePath, { read: true });
+    // Read file into memory
     const fileData = await Deno.readFile(tempFilePath);
-    file.close();
 
-    // Use the appropriate MIME type for the blob
-    const blobType = isVideoFile(fileType) ? "audio/mpeg" : fileType;
-    const fileBlob = new Blob([fileData], {
-      type: blobType,
-    });
+    // Use the appropriate MIME type
+    const mimeType = isVideoFile(fileType) ? "audio/mpeg" : fileType;
 
-    console.log("Sending to ElevenLabs API...");
-    const scribeResult = await elevenlabs.speechToText.convert({
-      file: fileBlob,
-      model_id: "scribe_v1",
-      tag_audio_events: options.tagAudioEvents,
-      diarize: options.diarize,
-      language_code: "ja",
-      ...(options.diarize && options.numSpeakers ? { num_speakers: options.numSpeakers } : {}),
-    }, { timeoutInSeconds: 180 });
-
-    const words: WordItem[] | undefined = (scribeResult as { words?: WordItem[] }).words;
-
-    if (options.diarize && Array.isArray(words) && words.length > 0) {
-      const grouped = groupBySpeaker(words);
-      transcript = grouped
-        .map((u) => {
-          const speakerLabel = typeof u.speaker === "number"
-            ? `speaker_${u.speaker}`
-            : `${u.speaker}`;
-          if (options.showTimestamp) {
-            return `${formatTimestamp(u.start)} ${speakerLabel}: ${u.text.trim()}`;
-          } else {
-            return `${speakerLabel}: ${u.text.trim()}`;
-          }
-        })
-        .join("\n");
-    } else if (!options.diarize && Array.isArray(words) && words.length > 0) {
-      const sentences = extractSentences(words);
-      transcript = sentences
-        .map((s) => {
-          if (options.showTimestamp) {
-            return `${formatTimestamp(s.start)} ${s.text}`;
-          } else {
-            return s.text;
-          }
-        })
-        .join("\n");
-    } else {
-      const plain = (scribeResult.text || "").trim();
-      transcript = plain.replace(/([。.!！?？])\s*/g, "$1\n").trim();
-    }
-
-    languageCode = (scribeResult as { language_code?: string }).language_code || null;
+    // Call the core transcription function
+    const result = await transcribeCore(fileData, mimeType, options);
+    
+    transcript = result.transcript;
+    languageCode = result.languageCode;
 
     if (transcript) {
-      // Apply speaker name mapping if provided
-      if (options.diarize && options.speakerNames && options.speakerNames.length > 0) {
-        try {
-          console.log("Identifying speakers with names:", options.speakerNames);
-          const speakerMapping = await identifySpeakers(transcript, options.speakerNames);
-          transcript = replaceSpeakerLabels(transcript, speakerMapping);
-          console.log("Speaker labels replaced successfully");
-        } catch (error) {
-          console.error("Failed to identify speakers:", error);
-          // Continue with original transcript if speaker identification fails
-        }
-      }
 
       // Add header with filename if provided
       const finalTranscript = filename

--- a/src/transcribe-core.ts
+++ b/src/transcribe-core.ts
@@ -120,7 +120,7 @@ export async function transcribeFile(
 ): Promise<TranscriptionResult> {
   let processedFilePath = filePath;
   let audioFilePath: string | null = null;
-  
+
   try {
     // Get file info
     const fileInfo = await Deno.stat(filePath);
@@ -131,7 +131,7 @@ export async function transcribeFile(
     // Determine MIME type based on file extension
     const extension = filePath.split('.').pop()?.toLowerCase() || '';
     const mimeType = getMimeType(extension);
-    
+
     // Check if the file is a video and convert to MP3 if needed
     if (isVideoFile(mimeType)) {
       console.log("Detected video file, converting to MP3...");
@@ -147,13 +147,13 @@ export async function transcribeFile(
 
     // Read the processed file (original audio or converted MP3)
     const fileData = await Deno.readFile(processedFilePath);
-    
+
     // Use the appropriate MIME type
     const finalMimeType = audioFilePath ? "audio/mpeg" : mimeType;
-    
+
     // Call the core transcription function
     const result = await transcribeCore(fileData, finalMimeType, options);
-    
+
     return result;
   } finally {
     // Clean up converted audio file if it was created

--- a/src/transcribe-core.ts
+++ b/src/transcribe-core.ts
@@ -1,0 +1,183 @@
+import { ElevenLabsClient } from "npm:elevenlabs@1.59.0";
+import {
+  TranscriptionOptions,
+  WordItem,
+} from "./types.ts";
+import {
+  formatTimestamp,
+  extractSentences,
+  groupBySpeaker,
+  isVideoFile,
+  convertVideoToAudio,
+} from "./utils.ts";
+import { identifySpeakers, replaceSpeakerLabels } from "./openai-client.ts";
+import { config } from "./config.ts";
+
+const elevenlabs = new ElevenLabsClient({
+  apiKey: config.elevenLabsApiKey,
+});
+
+export interface TranscriptionResult {
+  transcript: string;
+  languageCode: string | null;
+  words?: WordItem[];
+}
+
+/**
+ * Core transcription function that is platform-independent
+ * @param fileData - The audio/video file data as Uint8Array
+ * @param mimeType - MIME type of the file
+ * @param options - Transcription options
+ * @returns Transcription result
+ */
+export async function transcribeCore(
+  fileData: Uint8Array,
+  mimeType: string,
+  options: TranscriptionOptions
+): Promise<TranscriptionResult> {
+  console.log("Calling ElevenLabs API with options:", options);
+
+  // Create blob from file data
+  // Always use audio/mpeg for converted video files
+  const blobType = isVideoFile(mimeType) ? "audio/mpeg" : mimeType;
+  const fileBlob = new Blob([fileData], { type: blobType });
+
+  // Call ElevenLabs API
+  const scribeResult = await elevenlabs.speechToText.convert({
+    file: fileBlob,
+    model_id: "scribe_v1",
+    tag_audio_events: options.tagAudioEvents,
+    diarize: options.diarize,
+    language_code: "ja",
+    ...(options.diarize && options.numSpeakers ? { num_speakers: options.numSpeakers } : {}),
+  }, { timeoutInSeconds: 180 });
+
+  const words: WordItem[] | undefined = (scribeResult as { words?: WordItem[] }).words;
+  let transcript = "";
+
+  // Process transcription based on options
+  if (options.diarize && Array.isArray(words) && words.length > 0) {
+    const grouped = groupBySpeaker(words);
+    transcript = grouped
+      .map((u) => {
+        const speakerLabel = typeof u.speaker === "number"
+          ? `speaker_${u.speaker}`
+          : `${u.speaker}`;
+        if (options.showTimestamp) {
+          return `${formatTimestamp(u.start)} ${speakerLabel}: ${u.text.trim()}`;
+        } else {
+          return `${speakerLabel}: ${u.text.trim()}`;
+        }
+      })
+      .join("\n");
+  } else if (!options.diarize && Array.isArray(words) && words.length > 0) {
+    const sentences = extractSentences(words);
+    transcript = sentences
+      .map((s) => {
+        if (options.showTimestamp) {
+          return `${formatTimestamp(s.start)} ${s.text}`;
+        } else {
+          return s.text;
+        }
+      })
+      .join("\n");
+  } else {
+    const plain = (scribeResult.text || "").trim();
+    transcript = plain.replace(/([。.!！?？])\s*/g, "$1\n").trim();
+  }
+
+  // Apply speaker name mapping if provided
+  if (options.diarize && options.speakerNames && options.speakerNames.length > 0 && transcript) {
+    try {
+      console.log("Identifying speakers with names:", options.speakerNames);
+      const speakerMapping = await identifySpeakers(transcript, options.speakerNames);
+      transcript = replaceSpeakerLabels(transcript, speakerMapping);
+      console.log("Speaker labels replaced successfully");
+    } catch (error) {
+      console.error("Failed to identify speakers:", error);
+      // Continue with original transcript if speaker identification fails
+    }
+  }
+
+  const languageCode = (scribeResult as { language_code?: string }).language_code || null;
+
+  return {
+    transcript,
+    languageCode,
+    words,
+  };
+}
+
+/**
+ * Transcribe a file from disk
+ * @param filePath - Path to the audio/video file
+ * @param options - Transcription options
+ * @returns Transcription result
+ */
+export async function transcribeFile(
+  filePath: string,
+  options: TranscriptionOptions
+): Promise<TranscriptionResult> {
+  let processedFilePath = filePath;
+  let audioFilePath: string | null = null;
+  
+  try {
+    // Get file info
+    const fileInfo = await Deno.stat(filePath);
+    const fileSizeMB = fileInfo.size / (1024 * 1024);
+    console.log(`File: ${filePath}`);
+    console.log(`File size: ${fileSizeMB.toFixed(2)}MB`);
+
+    // Determine MIME type based on file extension
+    const extension = filePath.split('.').pop()?.toLowerCase() || '';
+    const mimeType = getMimeType(extension);
+    
+    // Check if the file is a video and convert to MP3 if needed
+    if (isVideoFile(mimeType)) {
+      console.log("Detected video file, converting to MP3...");
+      audioFilePath = await convertVideoToAudio(filePath);
+      processedFilePath = audioFilePath;
+      console.log("Conversion complete:", audioFilePath);
+    }
+
+    // Warn about large files
+    if (fileSizeMB > 200) {
+      console.warn(`Warning: Large file detected (${fileSizeMB.toFixed(2)}MB). This may exceed memory limits.`);
+    }
+
+    // Read the processed file (original audio or converted MP3)
+    const fileData = await Deno.readFile(processedFilePath);
+    
+    // Use the appropriate MIME type
+    const finalMimeType = audioFilePath ? "audio/mpeg" : mimeType;
+    
+    // Call the core transcription function
+    const result = await transcribeCore(fileData, finalMimeType, options);
+    
+    return result;
+  } finally {
+    // Clean up converted audio file if it was created
+    if (audioFilePath) {
+      console.log("Cleaning up converted audio file:", audioFilePath);
+      await Deno.remove(audioFilePath).catch(() => {});
+      const audioDir = audioFilePath.substring(0, audioFilePath.lastIndexOf("/"));
+      await Deno.remove(audioDir).catch(() => {});
+    }
+  }
+}
+
+function getMimeType(extension: string): string {
+  const mimeTypes: Record<string, string> = {
+    mp3: "audio/mpeg",
+    mp4: "video/mp4",
+    m4a: "audio/mp4",
+    wav: "audio/wav",
+    ogg: "audio/ogg",
+    webm: "video/webm",
+    avi: "video/x-msvideo",
+    mov: "video/quicktime",
+    mkv: "video/x-matroska",
+    flac: "audio/flac",
+  };
+  return mimeTypes[extension] || "application/octet-stream";
+}


### PR DESCRIPTION
## Summary
- 既存のbotモジュールを再利用したローカル文字起こし機能を追加
- `make transcribe`コマンドで簡単に音声/動画ファイルを文字起こし可能に
- elevenlabs-scribe-transcriberリポジトリを参考に実装

## Changes
### 新規ファイル
- `src/transcribe-core.ts` - プラットフォーム非依存の文字起こしコア機能
- `src/cli.ts` - コマンドラインインターフェース

### 既存ファイルの変更
- `src/scribe.ts` - transcribe-coreを使用するようにリファクタリング
- `Makefile` - `transcribe`コマンドを追加

## Features
- 🎙️ 音声/動画ファイルの文字起こし（動画は自動的にMP3変換）
- 👥 話者分離（デフォルト: 自動検出）
- 🏷️ 話者名の指定サポート
- ⏱️ タイムスタンプ表示
- 📁 デフォルトで`transcripts/`ディレクトリに保存
- 📄 テキスト/JSON形式の出力

## Usage
```bash
# 基本的な使い方
make transcribe FILE=audio.mp3

# オプション付き
make transcribe FILE=meeting.mp4 ARGS='--speaker-names "Alice,Bob" --output transcript.txt'

# 標準出力に表示
make transcribe FILE=audio.wav ARGS='--no-save'

# ヘルプ表示
deno run --allow-all src/cli.ts --help
```

## Test plan
- [x] 音声ファイル（MP3）の文字起こし
- [x] 動画ファイル（MP4）の自動変換と文字起こし
- [x] 話者分離機能の動作確認
- [x] .envファイルからのAPIキー読み込み
- [x] transcriptsディレクトリへの自動保存

🤖 Generated with [Claude Code](https://claude.ai/code)