### PR TITLE
Add HLS adapter for streaming transcription

### DIFF
--- a/src/adapters/hls-adapter.ts
+++ b/src/adapters/hls-adapter.ts
@@ -1,0 +1,37 @@
+import { BaseCloudService, CloudFileMetadata } from "../services/cloud-service.ts";
+import {
+  downloadHlsAudioToPath,
+  extractHlsStreamId,
+  getHlsFileMetadata,
+  isHlsUrl,
+} from "../clients/hls.ts";
+
+export class HlsAdapter extends BaseCloudService {
+  readonly name = "HLS";
+
+  isValidUrl(url: string): boolean {
+    return isHlsUrl(url);
+  }
+
+  extractFileId(url: string): string | null {
+    return extractHlsStreamId(url);
+  }
+
+  async getFileMetadata(streamUrl: string): Promise<CloudFileMetadata> {
+    return await getHlsFileMetadata(streamUrl);
+  }
+
+  async downloadFile(streamUrl: string, tempPath: string): Promise<boolean> {
+    await downloadHlsAudioToPath(streamUrl, tempPath);
+    return true;
+  }
+
+  getPreferredFileExtension(): string {
+    return "mp3";
+  }
+
+  isMediaFile(mimeType: string): boolean {
+    const lower = mimeType.toLowerCase();
+    return lower === "application/vnd.apple.mpegurl" || super.isMediaFile(mimeType);
+  }
+}

--- a/src/clients/hls.ts
+++ b/src/clients/hls.ts
@@ -1,0 +1,132 @@
+import { CloudFileMetadata } from "../services/cloud-service.ts";
+import { TempFileManager } from "../services/temp-file-manager.ts";
+
+const decoder = new TextDecoder();
+let ffmpegStatus: "unknown" | "available" | "missing" = "unknown";
+let ffmpegError: string | null = null;
+const tempManager = new TempFileManager();
+
+async function ensureFfmpegAvailable(): Promise<void> {
+  if (ffmpegStatus === "available") return;
+  if (ffmpegStatus === "missing") {
+    throw new Error(ffmpegError ?? "ffmpeg is not available");
+  }
+
+  try {
+    const command = new Deno.Command("ffmpeg", {
+      args: ["-version"],
+      stdout: "piped",
+      stderr: "piped",
+    });
+    const { success, stderr } = await command.output();
+
+    if (!success) {
+      const errorText = decoder.decode(stderr).trim();
+      ffmpegStatus = "missing";
+      ffmpegError = `ffmpeg check failed. Please ensure ffmpeg is installed and accessible in PATH. ${errorText}`.trim();
+      throw new Error(ffmpegError);
+    }
+
+    ffmpegStatus = "available";
+  } catch (error) {
+    ffmpegStatus = "missing";
+    ffmpegError = `ffmpeg is not installed or not accessible. ${error instanceof Error ? error.message : String(error)}`;
+    throw new Error(ffmpegError);
+  }
+}
+
+function sanitizeFilename(filename: string): string {
+  return filename
+    .replace(/[<>:"/\\|?*\x00-\x1F]/g, "_")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 200);
+}
+
+function deriveFilename(streamUrl: string): string {
+  try {
+    const url = new URL(streamUrl);
+    const pathSegments = url.pathname.split("/").filter(Boolean);
+    const lastSegment = pathSegments.pop() || "hls_stream.m3u8";
+    const baseName = lastSegment.toLowerCase().endsWith(".m3u8")
+      ? lastSegment.slice(0, -5)
+      : lastSegment;
+    const sanitized = sanitizeFilename(baseName || "hls_stream");
+    return `${sanitized}.mp3`;
+  } catch {
+    return "hls_stream.mp3";
+  }
+}
+
+export function isHlsUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    const protocol = parsed.protocol.toLowerCase();
+    if (protocol !== "http:" && protocol !== "https:") {
+      return false;
+    }
+
+    const path = parsed.pathname.toLowerCase();
+    return path.endsWith(".m3u8") || path.includes(".m3u8");
+  } catch {
+    return false;
+  }
+}
+
+export function extractHlsStreamId(url: string): string | null {
+  return isHlsUrl(url) ? url : null;
+}
+
+export async function getHlsFileMetadata(streamUrl: string): Promise<CloudFileMetadata> {
+  const filename = deriveFilename(streamUrl);
+  return {
+    id: streamUrl,
+    filename,
+    mimeType: "application/vnd.apple.mpegurl",
+  };
+}
+
+export async function downloadHlsAudioToPath(streamUrl: string, tempPath: string): Promise<boolean> {
+  await ensureFfmpegAvailable();
+
+  // Some HLS endpoints may reject repeated connections; create a fresh playlist copy first
+  const tempPlaylist = await tempManager.createTempFile("hls_playlist", "m3u8");
+  try {
+    const playlistResponse = await fetch(streamUrl);
+    if (!playlistResponse.ok) {
+      throw new Error(`Failed to fetch HLS playlist (status ${playlistResponse.status})`);
+    }
+    const playlistContent = await playlistResponse.text();
+    await Deno.writeTextFile(tempPlaylist, playlistContent);
+
+    const command = new Deno.Command("ffmpeg", {
+      args: [
+        "-y",
+        "-protocol_whitelist", "file,http,https,tcp,tls,crypto",
+        "-i", tempPlaylist,
+        "-vn",
+        "-acodec", "libmp3lame",
+        "-ab", "192k",
+        tempPath,
+      ],
+      stdout: "piped",
+      stderr: "piped",
+    });
+
+    const { success, stderr } = await command.output();
+
+    if (!success) {
+      const errorText = decoder.decode(stderr);
+      throw new Error(`ffmpeg failed to download HLS audio: ${errorText}`);
+    }
+
+    const stat = await Deno.stat(tempPath);
+    if (!stat.isFile || stat.size === 0) {
+      throw new Error("Downloaded audio file is empty");
+    }
+
+    return true;
+  } finally {
+    await tempManager.cleanupFileAndDir(tempPlaylist).catch(() => {});
+  }
+}

--- a/src/services/cloud-service-manager.ts
+++ b/src/services/cloud-service-manager.ts
@@ -8,6 +8,7 @@ import { GoogleDriveAdapter } from "../adapters/google-drive-adapter.ts";
 import { TempFileManager } from "./temp-file-manager.ts";
 import { DropboxAdapter } from "../adapters/dropbox-adapter.ts";
 import { YouTubeAdapter } from "../adapters/youtube-adapter.ts";
+import { HlsAdapter } from "../adapters/hls-adapter.ts";
 import { getErrorMessage } from "../utils/errors.ts";
 
 export class CloudServiceManager {
@@ -26,6 +27,7 @@ export class CloudServiceManager {
     cloudServiceRegistry.register(new GoogleDriveAdapter());
 
     // Future services can be registered here:
+    cloudServiceRegistry.register(new HlsAdapter());
     cloudServiceRegistry.register(new DropboxAdapter());
     cloudServiceRegistry.register(new YouTubeAdapter());
     // cloudServiceRegistry.register(new OneDriveService());


### PR DESCRIPTION
## Summary
- add an HLS client that validates .m3u8 URLs, derives filenames, and downloads audio with ffmpeg
- create an HLS cloud adapter and register it alongside existing services with mp3 output preference
- ensure downloaded streams are treated as media and handle playlist fetching safely

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692089445e40832281660ec1bf9bd955)