### PR TITLE
Add HLS streaming adapter

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -18,7 +18,13 @@
       "Bash(deno check:*)",
       "Bash(deno lint:*)",
       "Bash(mv:*)",
-      "Bash(find:*)"
+      "Bash(find:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(yt-dlp:*)",
+      "Bash(curl:*)",
+      "Bash(deno run:*)",
+      "Bash(deno eval:*)"
     ],
     "deny": [],
     "ask": []

--- a/src/adapters/hls-adapter.ts
+++ b/src/adapters/hls-adapter.ts
@@ -1,0 +1,32 @@
+import { BaseCloudService, CloudFileMetadata } from "../services/cloud-service.ts";
+import {
+  downloadHlsAudioToPath,
+  extractHlsStreamId,
+  getHlsFileMetadata,
+  isHlsUrl,
+} from "../clients/hls.ts";
+
+export class HlsAdapter extends BaseCloudService {
+  readonly name = "HLS";
+
+  isValidUrl(url: string): boolean {
+    return isHlsUrl(url);
+  }
+
+  extractFileId(url: string): string | null {
+    return extractHlsStreamId(url);
+  }
+
+  async getFileMetadata(streamUrl: string): Promise<CloudFileMetadata> {
+    return await getHlsFileMetadata(streamUrl);
+  }
+
+  async downloadFile(streamUrl: string, tempPath: string): Promise<boolean> {
+    await downloadHlsAudioToPath(streamUrl, tempPath);
+    return true;
+  }
+
+  getPreferredFileExtension(): string {
+    return "mp3";
+  }
+}

--- a/src/adapters/platform-adapter.ts
+++ b/src/adapters/platform-adapter.ts
@@ -2,6 +2,7 @@ import { TranscriptionOptions } from "../core/types.ts";
 import { formatOptionsText } from "../services/file-processor.ts";
 import { sendSlackMessage, uploadTranscriptToSlack, downloadSlackFileToPath } from "../clients/slack.ts";
 import { editInteractionReply, sendDiscordMessage, uploadTranscriptToDiscord, downloadDiscordFile } from "../clients/discord.ts";
+import { getDiscordUsageMessage, getSlackUsageMessage } from "../utils/messages.ts";
 // @ts-ignore: Types are provided in the deployment environment
 import { APIInteraction } from "npm:discord-api-types@0.37.100/v10";
 
@@ -51,23 +52,7 @@ export class SlackAdapter implements PlatformAdapter {
   }
 
   async sendUsageMessage(): Promise<void> {
-    const usageMessage = `📝 *使い方*\n\n` +
-      `音声または動画ファイルをアップロードしてメンションするか、\n` +
-      `Google DriveやDropbox、YouTube、HLS(.m3u8)のリンクを含めてメンションしてください。\n\n` +
-      `*オプション:*\n` +
-      `• \`--no-diarize\`: 話者識別を無効化\n` +
-      `• \`--no-timestamp\`: タイムスタンプを非表示\n` +
-      `• \`--no-audio-events\`: 音声イベント（拍手、音楽など）のタグを無効化\n` +
-      `• \`--no-summarize\`: 文字起こし後の要約送信をスキップ\n` +
-      `• \`--num-speakers <数>\`: 話者数を指定（デフォルト: 2）\n` +
-      `• \`--speaker-names "<名前1>,<名前2>"\`: 話者名を指定（AIが自動判定）\n\n` +
-      `*使用例:*\n` +
-      `@文字起こしKUN --no-timestamp --num-speakers 3\n` +
-      `@文字起こしKUN --speaker-names "田中,山田"\n` +
-      `@文字起こしKUN https://drive.google.com/file/d/xxxxx/view\n` +
-      `@文字起こしKUN https://www.youtube.com/watch?v=xxxxxxx`;
-
-    await this.sendStatusMessage(usageMessage);
+    await this.sendStatusMessage(getSlackUsageMessage());
   }
 
   formatProcessingMessage(filename: string, options: TranscriptionOptions): string {
@@ -112,23 +97,7 @@ export class DiscordAdapter implements PlatformAdapter {
   }
 
   async sendUsageMessage(): Promise<void> {
-    const usageMessage = `**🎙️概要**
-音声・動画ファイルやGoogle DriveやDropbox、YouTube、HLS(.m3u8)のURLから文字起こしを行います。
-チャット欄に/transcribeと入力で使用開始。
-
-**⚙️オプション**
-• \`--no-diarize\`: 話者識別をオフ ※話者が一人の場合には使用推奨
-• \`--num-speakers <数>\`: 話者数を指定（デフォルト:2）※指定することで話者識別の精度が向上します
-• \`--speaker-names 名前1,名前2\`: 話者名を設定（順不同、人数分必要）
-• \`--no-timestamp\`: タイムスタンプを非表示
-• \`--no-audio-events\`: 音声イベントを非表示
-• \`--no-summarize\`: 文字起こし後の要約送信をスキップ
-
-**⚠️注意点**
-•「アプリケーションが応答しませんでした」と表示されても、Discordの仕様によるもので処理は実行されています。
-•Google DriveやYouTubeなどのURLからの文字起こしは、元の公開設定に依存します。`;
-
-    await this.sendStatusMessage(usageMessage);
+    await this.sendStatusMessage(getDiscordUsageMessage());
   }
 
   formatProcessingMessage(filename: string, options: TranscriptionOptions): string {

--- a/src/adapters/platform-adapter.ts
+++ b/src/adapters/platform-adapter.ts
@@ -2,7 +2,7 @@ import { TranscriptionOptions } from "../core/types.ts";
 import { formatOptionsText } from "../services/file-processor.ts";
 import { sendSlackMessage, uploadTranscriptToSlack, downloadSlackFileToPath } from "../clients/slack.ts";
 import { editInteractionReply, sendDiscordMessage, uploadTranscriptToDiscord, downloadDiscordFile } from "../clients/discord.ts";
-import { getDiscordUsageMessage, getSlackUsageMessage } from "../utils/messages.ts";
+import { getUsageMessage } from "../utils/messages.ts";
 // @ts-ignore: Types are provided in the deployment environment
 import { APIInteraction } from "npm:discord-api-types@0.37.100/v10";
 
@@ -52,7 +52,7 @@ export class SlackAdapter implements PlatformAdapter {
   }
 
   async sendUsageMessage(): Promise<void> {
-    await this.sendStatusMessage(getSlackUsageMessage());
+    await this.sendStatusMessage(getUsageMessage());
   }
 
   formatProcessingMessage(filename: string, options: TranscriptionOptions): string {
@@ -97,7 +97,7 @@ export class DiscordAdapter implements PlatformAdapter {
   }
 
   async sendUsageMessage(): Promise<void> {
-    await this.sendStatusMessage(getDiscordUsageMessage());
+    await this.sendStatusMessage(getUsageMessage());
   }
 
   formatProcessingMessage(filename: string, options: TranscriptionOptions): string {

--- a/src/adapters/platform-adapter.ts
+++ b/src/adapters/platform-adapter.ts
@@ -53,7 +53,7 @@ export class SlackAdapter implements PlatformAdapter {
   async sendUsageMessage(): Promise<void> {
     const usageMessage = `📝 *使い方*\n\n` +
       `音声または動画ファイルをアップロードしてメンションするか、\n` +
-      `Google DriveやDropbox、YouTubeのリンクを含めてメンションしてください。\n\n` +
+      `Google DriveやDropbox、YouTube、HLS(.m3u8)のリンクを含めてメンションしてください。\n\n` +
       `*オプション:*\n` +
       `• \`--no-diarize\`: 話者識別を無効化\n` +
       `• \`--no-timestamp\`: タイムスタンプを非表示\n` +
@@ -113,7 +113,7 @@ export class DiscordAdapter implements PlatformAdapter {
 
   async sendUsageMessage(): Promise<void> {
     const usageMessage = `**🎙️概要**
-音声・動画ファイルやGoogle DriveやDropbox、YouTubeのURLから文字起こしを行います。
+音声・動画ファイルやGoogle DriveやDropbox、YouTube、HLS(.m3u8)のURLから文字起こしを行います。
 チャット欄に/transcribeと入力で使用開始。
 
 **⚙️オプション**

--- a/src/adapters/utage-adapter.ts
+++ b/src/adapters/utage-adapter.ts
@@ -1,0 +1,33 @@
+import { BaseCloudService, CloudFileMetadata } from "../services/cloud-service.ts";
+import {
+  downloadUtageAudioToPath,
+  extractUtageVideoId,
+  getUtageFileMetadata,
+  isUtageUrl,
+} from "../clients/utage.ts";
+
+export class UtageAdapter extends BaseCloudService {
+  readonly name = "Utage";
+
+  isValidUrl(url: string): boolean {
+    return isUtageUrl(url);
+  }
+
+  extractFileId(url: string): string | null {
+    // Return full URL as ID since we need it to fetch the page
+    return isUtageUrl(url) ? url : null;
+  }
+
+  async getFileMetadata(videoUrl: string): Promise<CloudFileMetadata> {
+    return await getUtageFileMetadata(videoUrl);
+  }
+
+  async downloadFile(videoUrl: string, tempPath: string): Promise<boolean> {
+    await downloadUtageAudioToPath(videoUrl, tempPath);
+    return true;
+  }
+
+  getPreferredFileExtension(): string {
+    return "mp3";
+  }
+}

--- a/src/adapters/youtube-adapter.ts
+++ b/src/adapters/youtube-adapter.ts
@@ -7,7 +7,7 @@ import {
 } from "../clients/youtube.ts";
 
 export class YouTubeAdapter extends BaseCloudService {
-  readonly name = "YouTube";
+  readonly name = "YouTube/Loom";
 
   isValidUrl(url: string): boolean {
     return isYouTubeUrl(url);

--- a/src/clients/hls.ts
+++ b/src/clients/hls.ts
@@ -1,0 +1,171 @@
+import { CloudFileMetadata } from "../services/cloud-service.ts";
+
+const decoder = new TextDecoder();
+
+let ffmpegStatus: "unknown" | "available" | "missing" = "unknown";
+let ffmpegError: string | null = null;
+
+async function ensureFfmpegAvailable(): Promise<void> {
+  if (ffmpegStatus === "available") {
+    return;
+  }
+
+  if (ffmpegStatus === "missing") {
+    throw new Error(ffmpegError ?? "ffmpeg is not available");
+  }
+
+  try {
+    const command = new Deno.Command("ffmpeg", {
+      args: ["-version"],
+      stdout: "piped",
+      stderr: "piped",
+    });
+    const { success, stderr } = await command.output();
+
+    if (!success) {
+      const errorText = decoder.decode(stderr).trim();
+      ffmpegStatus = "missing";
+      ffmpegError =
+        `ffmpeg check failed. Please ensure ffmpeg is installed and accessible in PATH. ${errorText}`
+          .trim();
+      throw new Error(ffmpegError);
+    }
+
+    ffmpegStatus = "available";
+  } catch (error) {
+    ffmpegStatus = "missing";
+    ffmpegError = `ffmpeg is not installed or not accessible. ${
+      error instanceof Error ? error.message : String(error)
+    }`;
+    throw new Error(ffmpegError);
+  }
+}
+
+function sanitizeFilename(filename: string): string {
+  return filename
+    .replace(/[<>:"/\\|?*\x00-\x1F]/g, "_")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 200);
+}
+
+export function isHlsUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    const pathname = parsed.pathname.toLowerCase();
+    const search = parsed.search.toLowerCase();
+
+    if (pathname.includes(".m3u8")) {
+      return true;
+    }
+
+    // Some HLS URLs include the playlist in query parameters
+    return search.includes(".m3u8") || search.includes("hls");
+  } catch {
+    return false;
+  }
+}
+
+export function extractHlsStreamId(url: string): string | null {
+  return isHlsUrl(url) ? url : null;
+}
+
+function deriveFilename(streamUrl: string): string {
+  try {
+    const parsed = new URL(streamUrl);
+    const pathname = parsed.pathname.split("/").filter(Boolean);
+    const lastSegment = pathname[pathname.length - 1] || "hls_audio";
+    const baseName = lastSegment.replace(/\.m3u8$/i, "") || "hls_audio";
+    return `${sanitizeFilename(baseName)}.mp3`;
+  } catch {
+    return "hls_audio.mp3";
+  }
+}
+
+async function probeDuration(streamUrl: string): Promise<number | undefined> {
+  try {
+    const command = new Deno.Command("ffprobe", {
+      args: [
+        "-v",
+        "error",
+        "-show_entries",
+        "format=duration",
+        "-of",
+        "default=noprint_wrappers=1:nokey=1",
+        streamUrl,
+      ],
+      stdout: "piped",
+      stderr: "piped",
+    });
+
+    const { success, stdout } = await command.output();
+    if (!success) return undefined;
+
+    const output = decoder.decode(stdout).trim();
+    if (!output) return undefined;
+
+    const duration = parseFloat(output);
+    return Number.isFinite(duration) ? duration : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function getHlsFileMetadata(streamUrl: string): Promise<CloudFileMetadata> {
+  await ensureFfmpegAvailable();
+  const filename = deriveFilename(streamUrl);
+  const duration = await probeDuration(streamUrl);
+
+  return {
+    id: streamUrl,
+    filename,
+    mimeType: "audio/mpeg",
+    duration,
+  };
+}
+
+export async function downloadHlsAudioToPath(
+  streamUrl: string,
+  outputPath: string,
+): Promise<void> {
+  await ensureFfmpegAvailable();
+
+  const command = new Deno.Command("ffmpeg", {
+    args: [
+      "-y",
+      "-i",
+      streamUrl,
+      "-vn",
+      "-acodec",
+      "libmp3lame",
+      "-b:a",
+      "192k",
+      "-loglevel",
+      "error",
+      outputPath,
+    ],
+    stdout: "piped",
+    stderr: "piped",
+  });
+
+  const { success, stderr } = await command.output();
+  if (!success) {
+    const errorText = decoder.decode(stderr).trim();
+    throw new Error(
+      `Failed to download or convert HLS audio: ${errorText || "Unknown error"}`,
+    );
+  }
+
+  try {
+    const stat = await Deno.stat(outputPath);
+    if (!stat.isFile || stat.size === 0) {
+      throw new Error("Output file is empty after ffmpeg conversion");
+    }
+  } catch (error) {
+    throw new Error(
+      `HLS audio output verification failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}

--- a/src/clients/utage.ts
+++ b/src/clients/utage.ts
@@ -1,0 +1,181 @@
+import { CloudFileMetadata } from "../services/cloud-service.ts";
+
+const decoder = new TextDecoder();
+
+/**
+ * Check if URL is a Utage video URL
+ */
+export function isUtageUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    const hostname = parsed.hostname.toLowerCase();
+    return hostname.includes("utage-system.com") && parsed.pathname.includes("/video/");
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Extract video ID from Utage URL
+ */
+export function extractUtageVideoId(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    const match = parsed.pathname.match(/\/video\/([^/?]+)/);
+    return match ? match[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetch HTML and extract m3u8 URL from Utage video page
+ */
+async function extractM3u8Url(videoUrl: string): Promise<string> {
+  try {
+    const response = await fetch(videoUrl);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch Utage page (status ${response.status})`);
+    }
+
+    const html = await response.text();
+
+    // Extract m3u8 URL from config object in the HTML
+    // Format: const config = {video_id: "...",src: "https://.../video.m3u8", ...};
+    const srcMatch = html.match(/src:\s*"([^"]+\.m3u8)"/);
+
+    if (!srcMatch || !srcMatch[1]) {
+      throw new Error("Could not find m3u8 URL in Utage video page");
+    }
+
+    return srcMatch[1];
+  } catch (error) {
+    throw new Error(
+      `Failed to extract m3u8 URL from Utage: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
+}
+
+/**
+ * Extract title from Utage video page
+ */
+async function extractTitle(videoUrl: string): Promise<string> {
+  try {
+    const response = await fetch(videoUrl);
+    if (!response.ok) {
+      return "utage_video";
+    }
+
+    const html = await response.text();
+
+    // Try to extract title from video element
+    const titleMatch = html.match(/title="([^"]+)"/);
+    if (titleMatch && titleMatch[1]) {
+      return titleMatch[1].replace(/\.(mp4|m3u8)$/i, "");
+    }
+
+    return "utage_video";
+  } catch {
+    return "utage_video";
+  }
+}
+
+function sanitizeFilename(filename: string): string {
+  return filename
+    .replace(/[<>:"/\\|?*\x00-\x1F]/g, "_")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 200);
+}
+
+/**
+ * Get metadata for Utage video
+ */
+export async function getUtageFileMetadata(videoUrl: string): Promise<CloudFileMetadata> {
+  const title = await extractTitle(videoUrl);
+  const sanitizedTitle = sanitizeFilename(title);
+  const filename = `${sanitizedTitle}.mp3`;
+
+  return {
+    id: videoUrl,
+    filename,
+    mimeType: "audio/mpeg",
+  };
+}
+
+/**
+ * Download Utage video audio
+ * Extracts m3u8 URL and uses ffmpeg to download and convert
+ */
+export async function downloadUtageAudioToPath(
+  videoUrl: string,
+  outputPath: string,
+): Promise<void> {
+  // Extract m3u8 URL from the page
+  const m3u8Url = await extractM3u8Url(videoUrl);
+
+  // Check ffmpeg availability
+  let ffmpegStatus: "unknown" | "available" | "missing" = "unknown";
+  try {
+    const command = new Deno.Command("ffmpeg", {
+      args: ["-version"],
+      stdout: "piped",
+      stderr: "piped",
+    });
+    const { success } = await command.output();
+
+    if (!success) {
+      throw new Error("ffmpeg is not available");
+    }
+    ffmpegStatus = "available";
+  } catch (error) {
+    throw new Error(
+      `ffmpeg is not installed or not accessible. ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
+
+  // Download and convert using ffmpeg
+  const command = new Deno.Command("ffmpeg", {
+    args: [
+      "-y",
+      "-i",
+      m3u8Url,
+      "-vn",
+      "-acodec",
+      "libmp3lame",
+      "-b:a",
+      "192k",
+      "-loglevel",
+      "error",
+      outputPath,
+    ],
+    stdout: "piped",
+    stderr: "piped",
+  });
+
+  const { success, stderr } = await command.output();
+  if (!success) {
+    const errorText = decoder.decode(stderr).trim();
+    throw new Error(
+      `Failed to download Utage audio: ${errorText || "Unknown error"}`,
+    );
+  }
+
+  // Verify output file
+  try {
+    const stat = await Deno.stat(outputPath);
+    if (!stat.isFile || stat.size === 0) {
+      throw new Error("Output file is empty after conversion");
+    }
+  } catch (error) {
+    throw new Error(
+      `Utage audio output verification failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}

--- a/src/clients/youtube.ts
+++ b/src/clients/youtube.ts
@@ -46,6 +46,10 @@ async function ensureYtDlpAvailable(): Promise<void> {
 }
 
 function createYouTubeWatchUrl(videoId: string): string {
+  // If videoId is a full URL (for Loom and other sites), return as-is
+  if (videoId.startsWith("http://") || videoId.startsWith("https://")) {
+    return videoId;
+  }
   return `https://www.youtube.com/watch?v=${videoId}`;
 }
 
@@ -158,8 +162,11 @@ export function isYouTubeUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
     const hostname = parsed.hostname.toLowerCase();
-    return hostname.includes("youtube.com") || hostname === "youtu.be" ||
-      hostname.endsWith("youtube-nocookie.com");
+    // Support YouTube and other yt-dlp compatible sites like Loom
+    return hostname.includes("youtube.com") ||
+           hostname === "youtu.be" ||
+           hostname.endsWith("youtube-nocookie.com") ||
+           hostname.includes("loom.com");
   } catch {
     return false;
   }
@@ -169,6 +176,11 @@ export function extractYouTubeVideoId(url: string): string | null {
   try {
     const parsed = new URL(url);
     const hostname = parsed.hostname.toLowerCase();
+
+    // For Loom and other yt-dlp sites, return the full URL
+    if (hostname.includes("loom.com")) {
+      return url;
+    }
 
     if (hostname === "youtu.be") {
       const id = parsed.pathname.replace(/^\//, "");

--- a/src/handlers/discord-handler.ts
+++ b/src/handlers/discord-handler.ts
@@ -27,7 +27,7 @@ import {
 import { createPlatformAdapter } from "../adapters/platform-adapter.ts";
 import { TranscriptionProcessor, FileAttachment } from "../services/transcription-processor.ts";
 import { getErrorMessage } from "../utils/errors.ts";
-import { getDiscordUsageMessage, getDiscordUnsupportedContentMessage } from "../utils/messages.ts";
+import { getUsageMessage, getUnsupportedContentMessage } from "../utils/messages.ts";
 
 /**
  * Execute async function in background without blocking response
@@ -123,7 +123,7 @@ function handleTranscribeCommand(
 
   // If neither URL nor file is provided
   if (!urlOption && !fileOption) {
-    return replyToInteraction(getDiscordUsageMessage(), true);
+    return replyToInteraction(getUsageMessage(), true);
   }
 
   // Defer the reply immediately (Discord requires response within 3 seconds)
@@ -170,7 +170,7 @@ function handleMessageCommand(
   const { cloudUrls } = extractMediaInfo(message.content || "");
 
   if ((!audioVideoAttachments || audioVideoAttachments.length === 0) && cloudUrls.length === 0) {
-    return replyToInteraction(getDiscordUnsupportedContentMessage(), true);
+    return replyToInteraction(getUnsupportedContentMessage(), true);
   }
 
   // Defer the reply immediately

--- a/src/handlers/discord-handler.ts
+++ b/src/handlers/discord-handler.ts
@@ -27,6 +27,7 @@ import {
 import { createPlatformAdapter } from "../adapters/platform-adapter.ts";
 import { TranscriptionProcessor, FileAttachment } from "../services/transcription-processor.ts";
 import { getErrorMessage } from "../utils/errors.ts";
+import { getDiscordUsageMessage, getDiscordUnsupportedContentMessage } from "../utils/messages.ts";
 
 /**
  * Execute async function in background without blocking response
@@ -122,22 +123,7 @@ function handleTranscribeCommand(
 
   // If neither URL nor file is provided
   if (!urlOption && !fileOption) {
-    const usageMessage = `**🎙️概要**
-音声・動画ファイルやGoogle DriveやDropbox、YouTube、HLS(.m3u8)のURLから文字起こしを行います。
-チャット欄に/transcribeと入力で使用開始。
-
-**⚙️オプション**
-• \`--no-diarize\`: 話者識別をオフ ※話者が一人の場合には使用推奨
-• \`--num-speakers <数>\`: 話者数を指定（デフォルト:2）※指定することで話者識別の精度が向上します
-• \`--speaker-names 名前1,名前2\`: 話者名を設定（順不同、人数分必要）
-• \`--no-timestamp\`: タイムスタンプを非表示
-• \`--no-audio-events\`: 音声イベントを非表示
-
-**⚠️注意点**
-•「アプリケーションが応答しませんでした」と表示されても、Discordの仕様によるもので処理は実行されています。
-•Google DriveやYouTubeなどのURLからの文字起こしは、元の公開設定に依存します。`;
-
-    return replyToInteraction(usageMessage, true);
+    return replyToInteraction(getDiscordUsageMessage(), true);
   }
 
   // Defer the reply immediately (Discord requires response within 3 seconds)
@@ -184,10 +170,7 @@ function handleMessageCommand(
   const { cloudUrls } = extractMediaInfo(message.content || "");
 
   if ((!audioVideoAttachments || audioVideoAttachments.length === 0) && cloudUrls.length === 0) {
-    return replyToInteraction(
-      "このメッセージには音声/動画ファイルまたはクラウドのURL(Google Drive/Dropbox/YouTube)が含まれていません。",
-      true,
-    );
+    return replyToInteraction(getDiscordUnsupportedContentMessage(), true);
   }
 
   // Defer the reply immediately

--- a/src/handlers/discord-handler.ts
+++ b/src/handlers/discord-handler.ts
@@ -123,7 +123,7 @@ function handleTranscribeCommand(
   // If neither URL nor file is provided
   if (!urlOption && !fileOption) {
     const usageMessage = `**🎙️概要**
-音声・動画ファイルやGoogle DriveやDropbox、YouTubeのURLから文字起こしを行います。
+音声・動画ファイルやGoogle DriveやDropbox、YouTube、HLS(.m3u8)のURLから文字起こしを行います。
 チャット欄に/transcribeと入力で使用開始。
 
 **⚙️オプション**

--- a/src/services/cloud-service-manager.ts
+++ b/src/services/cloud-service-manager.ts
@@ -8,6 +8,7 @@ import { GoogleDriveAdapter } from "../adapters/google-drive-adapter.ts";
 import { TempFileManager } from "./temp-file-manager.ts";
 import { DropboxAdapter } from "../adapters/dropbox-adapter.ts";
 import { YouTubeAdapter } from "../adapters/youtube-adapter.ts";
+import { HlsAdapter } from "../adapters/hls-adapter.ts";
 import { getErrorMessage } from "../utils/errors.ts";
 
 export class CloudServiceManager {
@@ -28,6 +29,7 @@ export class CloudServiceManager {
     // Future services can be registered here:
     cloudServiceRegistry.register(new DropboxAdapter());
     cloudServiceRegistry.register(new YouTubeAdapter());
+    cloudServiceRegistry.register(new HlsAdapter());
     // cloudServiceRegistry.register(new OneDriveService());
     // cloudServiceRegistry.register(new BoxService());
   }

--- a/src/services/cloud-service-manager.ts
+++ b/src/services/cloud-service-manager.ts
@@ -9,6 +9,7 @@ import { TempFileManager } from "./temp-file-manager.ts";
 import { DropboxAdapter } from "../adapters/dropbox-adapter.ts";
 import { YouTubeAdapter } from "../adapters/youtube-adapter.ts";
 import { HlsAdapter } from "../adapters/hls-adapter.ts";
+import { UtageAdapter } from "../adapters/utage-adapter.ts";
 import { getErrorMessage } from "../utils/errors.ts";
 
 export class CloudServiceManager {
@@ -29,6 +30,7 @@ export class CloudServiceManager {
     // Future services can be registered here:
     cloudServiceRegistry.register(new DropboxAdapter());
     cloudServiceRegistry.register(new YouTubeAdapter());
+    cloudServiceRegistry.register(new UtageAdapter());
     cloudServiceRegistry.register(new HlsAdapter());
     // cloudServiceRegistry.register(new OneDriveService());
     // cloudServiceRegistry.register(new BoxService());

--- a/src/services/cloud-service.ts
+++ b/src/services/cloud-service.ts
@@ -8,6 +8,7 @@ export interface CloudFileMetadata {
   filename: string;
   mimeType: string;
   size?: number;
+  duration?: number;
 }
 
 export interface CloudDownloadResult {

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -34,7 +34,13 @@ export function getUsageMessage(): string {
 • \`--speaker-names <名前1,名前2>\`: 話者名を指定
 • \`--no-timestamp\`: タイムスタンプ非表示
 • \`--no-audio-events\`: 音声イベント非表示
-• \`--no-summarize\`: 要約スキップ`;
+• \`--no-summarize\`: 要約スキップ
+
+**使用例**
+• \`--num-speakers 3\`
+• \`--speaker-names 田中,山田 --no-timestamp\`
+• \`https://www.youtube.com/watch?v=xxxxx\`
+• \`https://utage-system.com/video/xxxxx\``;
 }
 
 /**
@@ -43,8 +49,3 @@ export function getUsageMessage(): string {
 export function getUnsupportedContentMessage(): string {
   return `音声/動画ファイルまたは対応URL(${getSupportedServicesList()})を送信してください。`;
 }
-
-// Backward compatibility aliases
-export const getDiscordUsageMessage = getUsageMessage;
-export const getSlackUsageMessage = getUsageMessage;
-export const getDiscordUnsupportedContentMessage = getUnsupportedContentMessage;

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -1,0 +1,50 @@
+/**
+ * Centralized message constants for bot responses
+ * Used across Discord and Slack handlers
+ */
+
+/**
+ * List of supported services for usage messages
+ */
+export const SUPPORTED_SERVICES = [
+  "Google Drive",
+  "Dropbox",
+  "YouTube",
+  "Loom",
+  "Utage",
+  "HLS(.m3u8)",
+];
+
+/**
+ * Get formatted list of supported services
+ */
+function getSupportedServicesList(): string {
+  return SUPPORTED_SERVICES.join("、");
+}
+
+/**
+ * Unified usage message for both Discord and Slack
+ */
+export function getUsageMessage(): string {
+  return `🎙️ 音声・動画ファイルまたは${getSupportedServicesList()}のURLから文字起こしができます。
+
+**オプション**
+• \`--no-diarize\`: 話者識別OFF（一人の場合に推奨）
+• \`--num-speakers <数>\`: 話者数を指定（デフォルト:2）
+• \`--speaker-names <名前1,名前2>\`: 話者名を指定
+• \`--no-timestamp\`: タイムスタンプ非表示
+• \`--no-audio-events\`: 音声イベント非表示
+• \`--no-summarize\`: 要約スキップ`;
+}
+
+/**
+ * Error message for unsupported content
+ */
+export function getUnsupportedContentMessage(): string {
+  return `音声/動画ファイルまたは対応URL(${getSupportedServicesList()})を送信してください。`;
+}
+
+// Backward compatibility aliases
+export const getDiscordUsageMessage = getUsageMessage;
+export const getSlackUsageMessage = getUsageMessage;
+export const getDiscordUnsupportedContentMessage = getUnsupportedContentMessage;


### PR DESCRIPTION
## Summary
- add an HLS client that validates m3u8 URLs, extracts metadata via ffprobe, and converts streams to MP3 with ffmpeg
- introduce an HLS adapter that plugs into the cloud service registry for HLS URL handling
- extend cloud file metadata to carry optional duration information

## Testing
- `deno fmt src/clients/hls.ts src/adapters/hls-adapter.ts src/services/cloud-service-manager.ts src/services/cloud-service.ts` *(fails: command not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692089445e40832281660ec1bf9bd955)