### PR TITLE
Slackボットにインタラクティブモーダル機能を追加

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -24,7 +24,8 @@
       "Bash(yt-dlp:*)",
       "Bash(curl:*)",
       "Bash(deno run:*)",
-      "Bash(deno eval:*)"
+      "Bash(deno eval:*)",
+      "Bash(tree:*)"
     ],
     "deny": [],
     "ask": []

--- a/src/clients/slack.ts
+++ b/src/clients/slack.ts
@@ -1,9 +1,13 @@
 import { config } from "../core/config.ts";
 
+// deno-lint-ignore no-explicit-any
+type SlackBlock = any;
+
 export async function sendSlackMessage(
   channel: string,
   text: string,
   threadTs?: string,
+  blocks?: SlackBlock[],
 ) {
   const response = await fetch("https://slack.com/api/chat.postMessage", {
     method: "POST",
@@ -15,6 +19,53 @@ export async function sendSlackMessage(
       channel,
       text,
       thread_ts: threadTs,
+      ...(blocks && { blocks }),
+    }),
+  });
+
+  return await response.json();
+}
+
+/**
+ * Open a modal dialog in Slack
+ */
+export async function openSlackModal(
+  triggerId: string,
+  // deno-lint-ignore no-explicit-any
+  view: any,
+) {
+  const response = await fetch("https://slack.com/api/views.open", {
+    method: "POST",
+    headers: {
+      "Authorization": `Bearer ${config.slackBotToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      trigger_id: triggerId,
+      view,
+    }),
+  });
+
+  return await response.json();
+}
+
+/**
+ * Update an existing modal view in Slack
+ */
+export async function updateSlackModal(
+  viewId: string,
+  // deno-lint-ignore no-explicit-any
+  view: any,
+) {
+  const response = await fetch("https://slack.com/api/views.update", {
+    method: "POST",
+    headers: {
+      "Authorization": `Bearer ${config.slackBotToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      view_id: viewId,
+      view,
     }),
   });
 

--- a/src/handlers/slack-handler.ts
+++ b/src/handlers/slack-handler.ts
@@ -11,6 +11,8 @@ import {
 } from "../services/file-processor.ts";
 import { createPlatformAdapter } from "../adapters/platform-adapter.ts";
 import { TranscriptionProcessor, FileAttachment } from "../services/transcription-processor.ts";
+import { sendSlackMessage } from "../clients/slack.ts";
+import { createTranscriptionButtonBlocks } from "./slack-interaction-handler.ts";
 
 // Set to track processed events (with size limit to prevent memory leak)
 const processedEvents = new Set<string>();
@@ -67,8 +69,14 @@ export async function handleAppMention(event: SlackEvent) {
 
   // Check if the mention includes files or cloud URLs
   if ((!event.files || event.files.length === 0) && cloudUrls.length === 0) {
-    const { adapter } = createSlackProcessor(event);
-    await adapter.sendUsageMessage();
+    // Send button message for interactive transcription setup
+    const blocks = createTranscriptionButtonBlocks();
+    await sendSlackMessage(
+      event.channel,
+      "🎙️ 文字起こしボット - 設定して実行ボタンを押してください",
+      event.ts,
+      blocks
+    );
     return;
   }
 

--- a/src/handlers/slack-interaction-handler.ts
+++ b/src/handlers/slack-interaction-handler.ts
@@ -1,0 +1,430 @@
+/**
+ * Slack interaction handler for buttons and modals
+ */
+
+import { openSlackModal, updateSlackModal, sendSlackMessage } from "../clients/slack.ts";
+import { okResponse, jsonResponse, badRequest } from "../utils/http-utils.ts";
+import { createPlatformAdapter } from "../adapters/platform-adapter.ts";
+import { TranscriptionProcessor } from "../services/transcription-processor.ts";
+import { TranscriptionOptions } from "../core/types.ts";
+import { extractMediaInfo } from "../services/file-processor.ts";
+
+/**
+ * Create the transcription options modal view
+ * @param diarizeEnabled - Whether speaker diarization is enabled (affects visibility of speaker options)
+ * @param currentValues - Current form values to preserve when updating modal
+ */
+function createTranscriptionModal(
+  channelId: string,
+  threadTs: string,
+  diarizeEnabled: boolean = true,
+  currentValues?: {
+    url?: string;
+    numSpeakers?: string;
+    speakerNames?: string;
+    timestamp?: string;
+    audioEvents?: string;
+    summarize?: string;
+  }
+) {
+  // deno-lint-ignore no-explicit-any
+  const blocks: any[] = [
+    {
+      type: "input",
+      block_id: "url_block",
+      optional: true,
+      element: {
+        type: "plain_text_input",
+        action_id: "url_input",
+        placeholder: {
+          type: "plain_text",
+          text: "https://drive.google.com/... など",
+        },
+        ...(currentValues?.url && { initial_value: currentValues.url }),
+      },
+      label: {
+        type: "plain_text",
+        text: "📎 ファイルURL",
+      },
+      hint: {
+        type: "plain_text",
+        text: "対応: Google Drive, Dropbox, Loom, Vimeo, Utage（公開設定が必要）",
+      },
+    },
+    {
+      type: "section",
+      block_id: "diarize_block",
+      text: {
+        type: "mrkdwn",
+        text: "*👥 話者分離*",
+      },
+      accessory: {
+        type: "static_select",
+        action_id: "diarize_select",
+        initial_option: diarizeEnabled
+          ? { text: { type: "plain_text", text: "有効" }, value: "true" }
+          : { text: { type: "plain_text", text: "無効（1人の場合）" }, value: "false" },
+        options: [
+          {
+            text: { type: "plain_text", text: "有効" },
+            value: "true",
+          },
+          {
+            text: { type: "plain_text", text: "無効（1人の場合）" },
+            value: "false",
+          },
+        ],
+      },
+    },
+  ];
+
+  // Only add speaker options if diarize is enabled
+  if (diarizeEnabled) {
+    blocks.push(
+      {
+        type: "input",
+        block_id: "num_speakers_block",
+        optional: true,
+        element: {
+          type: "static_select",
+          action_id: "num_speakers_select",
+          initial_option: {
+            text: { type: "plain_text", text: `${currentValues?.numSpeakers || "2"}人` },
+            value: currentValues?.numSpeakers || "2",
+          },
+          options: [1, 2, 3, 4, 5, 6, 7, 8].map((n) => ({
+            text: { type: "plain_text", text: `${n}人` },
+            value: String(n),
+          })),
+        },
+        label: {
+          type: "plain_text",
+          text: "🔢 話者数",
+        },
+      },
+      {
+        type: "input",
+        block_id: "speaker_names_block",
+        optional: true,
+        element: {
+          type: "plain_text_input",
+          action_id: "speaker_names_input",
+          placeholder: {
+            type: "plain_text",
+            text: "田中,山田,佐藤",
+          },
+          ...(currentValues?.speakerNames && { initial_value: currentValues.speakerNames }),
+        },
+        label: {
+          type: "plain_text",
+          text: "📝 話者名（カンマ区切り）",
+        },
+      }
+    );
+  }
+
+  // Add remaining options
+  blocks.push(
+    {
+      type: "section",
+      block_id: "timestamp_block",
+      text: {
+        type: "mrkdwn",
+        text: "*⏱️ タイムスタンプ*",
+      },
+      accessory: {
+        type: "static_select",
+        action_id: "timestamp_select",
+        initial_option: (currentValues?.timestamp === "false")
+          ? { text: { type: "plain_text", text: "非表示" }, value: "false" }
+          : { text: { type: "plain_text", text: "表示" }, value: "true" },
+        options: [
+          {
+            text: { type: "plain_text", text: "表示" },
+            value: "true",
+          },
+          {
+            text: { type: "plain_text", text: "非表示" },
+            value: "false",
+          },
+        ],
+      },
+    },
+    {
+      type: "section",
+      block_id: "audio_events_block",
+      text: {
+        type: "mrkdwn",
+        text: "*🎵 音声イベント（笑い声等）*",
+      },
+      accessory: {
+        type: "static_select",
+        action_id: "audio_events_select",
+        initial_option: (currentValues?.audioEvents === "false")
+          ? { text: { type: "plain_text", text: "非表示" }, value: "false" }
+          : { text: { type: "plain_text", text: "表示" }, value: "true" },
+        options: [
+          {
+            text: { type: "plain_text", text: "表示" },
+            value: "true",
+          },
+          {
+            text: { type: "plain_text", text: "非表示" },
+            value: "false",
+          },
+        ],
+      },
+    },
+    {
+      type: "section",
+      block_id: "summarize_block",
+      text: {
+        type: "mrkdwn",
+        text: "*📋 要約生成*",
+      },
+      accessory: {
+        type: "static_select",
+        action_id: "summarize_select",
+        initial_option: (currentValues?.summarize === "false")
+          ? { text: { type: "plain_text", text: "しない" }, value: "false" }
+          : { text: { type: "plain_text", text: "する" }, value: "true" },
+        options: [
+          {
+            text: { type: "plain_text", text: "する" },
+            value: "true",
+          },
+          {
+            text: { type: "plain_text", text: "しない" },
+            value: "false",
+          },
+        ],
+      },
+    }
+  );
+
+  return {
+    type: "modal",
+    callback_id: "transcription_modal",
+    private_metadata: JSON.stringify({ channelId, threadTs }),
+    title: {
+      type: "plain_text",
+      text: "文字起こし設定",
+    },
+    submit: {
+      type: "plain_text",
+      text: "実行",
+    },
+    close: {
+      type: "plain_text",
+      text: "キャンセル",
+    },
+    blocks,
+  };
+}
+
+/**
+ * Create the initial button message for file-less mentions
+ */
+export function createTranscriptionButtonBlocks() {
+  return [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "🎙️ *文字起こしボット*\n音声・動画ファイルのURLから文字起こしを行います。",
+      },
+    },
+    {
+      type: "actions",
+      block_id: "transcription_actions",
+      elements: [
+        {
+          type: "button",
+          text: {
+            type: "plain_text",
+            text: "⚙️ 設定して実行",
+            emoji: true,
+          },
+          style: "primary",
+          action_id: "open_transcription_modal",
+        },
+      ],
+    },
+  ];
+}
+
+/**
+ * Handle button click to open modal
+ */
+async function handleButtonClick(payload: {
+  trigger_id: string;
+  channel: { id: string };
+  message: { ts: string };
+}) {
+  const view = createTranscriptionModal(
+    payload.channel.id,
+    payload.message.ts
+  );
+
+  const result = await openSlackModal(payload.trigger_id, view);
+  if (!result.ok) {
+    console.error("Failed to open modal:", result.error);
+  }
+}
+
+/**
+ * Parse modal submission values into TranscriptionOptions
+ */
+function parseModalValues(values: Record<string, Record<string, { value?: string; selected_option?: { value: string } }>>): {
+  options: TranscriptionOptions;
+  url: string | null;
+} {
+  const getSelectValue = (blockId: string, actionId: string): string | undefined => {
+    return values[blockId]?.[actionId]?.selected_option?.value;
+  };
+
+  const getInputValue = (blockId: string, actionId: string): string | undefined => {
+    return values[blockId]?.[actionId]?.value;
+  };
+
+  const diarize = getSelectValue("diarize_block", "diarize_select") !== "false";
+  const showTimestamp = getSelectValue("timestamp_block", "timestamp_select") !== "false";
+  const tagAudioEvents = getSelectValue("audio_events_block", "audio_events_select") !== "false";
+  const summarize = getSelectValue("summarize_block", "summarize_select") !== "false";
+
+  const numSpeakersStr = getSelectValue("num_speakers_block", "num_speakers_select");
+  const numSpeakers = numSpeakersStr ? parseInt(numSpeakersStr, 10) : 2;
+
+  const speakerNamesStr = getInputValue("speaker_names_block", "speaker_names_input");
+  const speakerNames = speakerNamesStr
+    ? speakerNamesStr.split(/[,，]/).map((s) => s.trim()).filter(Boolean)
+    : undefined;
+
+  const url = getInputValue("url_block", "url_input") || null;
+
+  return {
+    options: {
+      diarize,
+      showTimestamp,
+      tagAudioEvents,
+      numSpeakers: diarize ? numSpeakers : undefined,
+      speakerNames: diarize && speakerNames?.length ? speakerNames : undefined,
+      summarize,
+    },
+    url,
+  };
+}
+
+/**
+ * Handle modal submission
+ */
+async function handleModalSubmission(payload: {
+  view: {
+    private_metadata: string;
+    state: {
+      values: Record<string, Record<string, { value?: string; selected_option?: { value: string } }>>;
+    };
+  };
+  user: { id: string };
+}) {
+  const { channelId, threadTs } = JSON.parse(payload.view.private_metadata);
+  const { options, url } = parseModalValues(payload.view.state.values);
+
+  if (!url) {
+    await sendSlackMessage(
+      channelId,
+      "❌ URLを入力してください。",
+      threadTs
+    );
+    return;
+  }
+
+  // Check if URL is valid
+  const { cloudUrls } = extractMediaInfo(url);
+  if (cloudUrls.length === 0) {
+    await sendSlackMessage(
+      channelId,
+      "❌ 対応していないURLです。Google Drive、YouTube、Dropbox等のURLを入力してください。",
+      threadTs
+    );
+    return;
+  }
+
+  // Create adapter and processor
+  const adapter = createPlatformAdapter("slack", {
+    channelId,
+    threadTimestamp: threadTs,
+  });
+
+  const processor = new TranscriptionProcessor(adapter, {
+    channelId,
+    timestamp: threadTs,
+    userId: payload.user.id,
+  });
+
+  // Process in background
+  processor.processTextInput(url, options)
+    .catch(console.error)
+    .finally(() => processor.cleanup());
+}
+
+/**
+ * Main Slack interactions handler
+ */
+export async function handleSlackInteractions(req: Request): Promise<Response> {
+  const formData = await req.formData();
+  const payloadStr = formData.get("payload");
+
+  if (!payloadStr || typeof payloadStr !== "string") {
+    return badRequest("Missing payload");
+  }
+
+  const payload = JSON.parse(payloadStr);
+  console.log("Slack interaction type:", payload.type);
+
+  // Handle button clicks and select changes
+  if (payload.type === "block_actions") {
+    const action = payload.actions?.[0];
+
+    if (action?.action_id === "open_transcription_modal") {
+      await handleButtonClick(payload);
+      return okResponse();
+    }
+
+    // Handle diarize select change - update modal to show/hide speaker options
+    if (action?.action_id === "diarize_select") {
+      const diarizeEnabled = action.selected_option?.value === "true";
+      const { channelId, threadTs } = JSON.parse(payload.view.private_metadata);
+      const values = payload.view.state.values;
+
+      // Extract current values to preserve them
+      const currentValues = {
+        url: values.url_block?.url_input?.value,
+        numSpeakers: values.num_speakers_block?.num_speakers_select?.selected_option?.value,
+        speakerNames: values.speaker_names_block?.speaker_names_input?.value,
+        timestamp: values.timestamp_block?.timestamp_select?.selected_option?.value,
+        audioEvents: values.audio_events_block?.audio_events_select?.selected_option?.value,
+        summarize: values.summarize_block?.summarize_select?.selected_option?.value,
+      };
+
+      const updatedView = createTranscriptionModal(channelId, threadTs, diarizeEnabled, currentValues);
+      const result = await updateSlackModal(payload.view.id, updatedView);
+      if (!result.ok) {
+        console.error("Failed to update modal:", result.error);
+      }
+      return okResponse();
+    }
+  }
+
+  // Handle modal submissions
+  if (payload.type === "view_submission") {
+    if (payload.view?.callback_id === "transcription_modal") {
+      // Respond immediately to avoid timeout
+      handleModalSubmission(payload).catch(console.error);
+      // Slack requires empty JSON body for view_submission
+      return jsonResponse({});
+    }
+  }
+
+  return okResponse();
+}

--- a/src/handlers/slack-interaction-handler.ts
+++ b/src/handlers/slack-interaction-handler.ts
@@ -230,7 +230,7 @@ export function createTranscriptionButtonBlocks() {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: "🎙️ *文字起こしボット*\n音声・動画ファイルのURLから文字起こしを行います。",
+        text: "🎙️ *文字起こしボット*\n\n*URLから文字起こし*\n下のボタンから設定・実行できます\n\n*ファイルから文字起こし*\nファイルを添付してメンションしてください",
       },
     },
     {
@@ -241,7 +241,7 @@ export function createTranscriptionButtonBlocks() {
           type: "button",
           text: {
             type: "plain_text",
-            text: "⚙️ 設定して実行",
+            text: "⚙️ URLから文字起こし",
             emoji: true,
           },
           style: "primary",

--- a/src/handlers/slack-interaction-handler.ts
+++ b/src/handlers/slack-interaction-handler.ts
@@ -32,7 +32,6 @@ function createTranscriptionModal(
     {
       type: "input",
       block_id: "url_block",
-      optional: true,
       element: {
         type: "plain_text_input",
         action_id: "url_input",
@@ -44,7 +43,7 @@ function createTranscriptionModal(
       },
       label: {
         type: "plain_text",
-        text: "📎 ファイルURL",
+        text: "📎 ファイルURL（必須）",
       },
       hint: {
         type: "plain_text",

--- a/src/handlers/slack-interaction-handler.ts
+++ b/src/handlers/slack-interaction-handler.ts
@@ -230,7 +230,7 @@ export function createTranscriptionButtonBlocks() {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: "🎙️ *文字起こしボット*\n\n*URLから文字起こし*\n下のボタンから設定・実行できます\n\n*ファイルから文字起こし*\nファイルを添付してメンションしてください",
+        text: "🎙️ *文字起こしボット*\n\n*URLから文字起こし*\n下のボタンから設定・実行できます",
       },
     },
     {
@@ -248,6 +248,16 @@ export function createTranscriptionButtonBlocks() {
           action_id: "open_transcription_modal",
         },
       ],
+    },
+    {
+      type: "divider",
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "*ファイルから文字起こし*\nファイルを添付して `@bot` とメンションしてください\n\n*オプション（任意）*\n• `--no-diarize` : 話者分離OFF（1人の場合に推奨）\n• `--num-speakers 3` : 話者数を指定\n• `--speaker-names 田中,山田` : 話者名を指定\n• `--no-timestamp` : タイムスタンプ非表示\n• `--no-summarize` : 要約をスキップ\n\n例: `@bot --num-speakers 3 --speaker-names 田中,山田,佐藤`",
+      },
     },
   ];
 }

--- a/src/handlers/slack-interaction-handler.ts
+++ b/src/handlers/slack-interaction-handler.ts
@@ -256,7 +256,7 @@ export function createTranscriptionButtonBlocks() {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: "*ファイルから文字起こし*\nファイルを添付して `@bot` とメンションしてください\n\n*オプション（任意）*\n• `--no-diarize` : 話者分離OFF（1人の場合に推奨）\n• `--num-speakers 3` : 話者数を指定\n• `--speaker-names 田中,山田` : 話者名を指定\n• `--no-timestamp` : タイムスタンプ非表示\n• `--no-summarize` : 要約をスキップ\n\n例: `@bot --num-speakers 3 --speaker-names 田中,山田,佐藤`",
+        text: "*ファイルから文字起こし*\nファイルを添付して `@bot` にメンションしてください\n\n*オプション（任意）*\n• `--no-diarize` : 話者分離OFF（1人の場合に推奨）\n• `--num-speakers 3` : 話者数を指定\n• `--speaker-names 田中,山田,佐藤` : 話者名を指定(話者数と揃える)\n• `--no-timestamp` : タイムスタンプ非表示\n• `--no-summarize` : 要約をスキップ\n\n例: `@bot --num-speakers 3 --speaker-names 田中,山田,佐藤`",
       },
     },
   ];

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { handleDiscordInteraction } from "./handlers/discord-handler.ts";
 import { handleSlackEvents } from "./handlers/slack-handler.ts";
+import { handleSlackInteractions } from "./handlers/slack-interaction-handler.ts";
 import { config } from "./core/config.ts";
 import { textResponse, methodNotAllowed } from "./utils/http-utils.ts";
 
@@ -26,9 +27,14 @@ Deno.serve({ port }, async (req) => {
     return await handleDiscordInteraction(req);
   }
 
-  // Slack endpoint
+  // Slack events endpoint
   if (pathname === "/slack/events" && req.method === "POST") {
     return await handleSlackEvents(req);
+  }
+
+  // Slack interactions endpoint (buttons, modals)
+  if (pathname === "/slack/interactions" && req.method === "POST") {
+    return await handleSlackInteractions(req);
   }
 
   return methodNotAllowed(['GET', 'POST']);


### PR DESCRIPTION
## Summary
- ファイルなしでボットにメンションした際に、ボタン付きメッセージを表示
- ボタンクリックでオプション設定用のモーダルを開く機能を追加
- 話者分離ON/OFF切り替え時にモーダルを動的更新（話者数・話者名フィールドの表示/非表示）
- ファイル添付ありの場合は従来通り即座に文字起こし実行（後方互換性維持）

## 変更内容
- `/slack/interactions` エンドポイントを追加
- Block Kit のボタンとモーダルを実装
- `views.open` / `views.update` APIを使用したモーダル操作

## Slack App設定で必要な変更
1. **Interactivity & Shortcuts** → **Interactivity** を **On** に切り替え
2. **Request URL** に設定: `https://scribe-bot-uzp7pov4qq-an.a.run.app/slack/interactions`

## Test plan
- [ ] ファイルなしでメンション → ボタン付きメッセージが表示される
- [ ] 「設定して実行」ボタンをクリック → モーダルが開く
- [ ] 話者分離を「無効」に変更 → 話者数・話者名フィールドが非表示になる
- [ ] URLを入力して「実行」 → 文字起こしが開始される
- [ ] ファイル添付してメンション → 従来通り即座に文字起こしが開始される（後方互換性）

🤖 Generated with [Claude Code](https://claude.com/claude-code)