### PR TITLE
feat: 話者名から話者数を自動設定するように改善

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,22 +43,27 @@ function parseArgs(): { filePath: string; options: CliOptions } {
     summarize: !args.includes("--no-summarize"),
   };
 
-  // Parse speaker count
-  const speakerIndex = args.indexOf("--num-speakers");
-  if (speakerIndex !== -1 && args[speakerIndex + 1]) {
-    const num = parseInt(args[speakerIndex + 1], 10);
-    if (!isNaN(num) && num > 0) {
-      options.numSpeakers = num;
-    }
-  }
-
-  // Parse speaker names
+  // Parse speaker names first (takes priority for determining numSpeakers)
   const speakerNamesIndex = args.indexOf("--speaker-names");
   if (speakerNamesIndex !== -1 && args[speakerNamesIndex + 1]) {
     options.speakerNames = args[speakerNamesIndex + 1]
       .split(",")
       .map((s) => s.trim())
       .filter((s) => s.length > 0);
+  }
+
+  // Determine numSpeakers: speakerNames takes priority if provided
+  if (options.speakerNames && options.speakerNames.length > 0) {
+    options.numSpeakers = options.speakerNames.length;
+  } else {
+    // Parse speaker count only if speaker names are not provided
+    const speakerIndex = args.indexOf("--num-speakers");
+    if (speakerIndex !== -1 && args[speakerIndex + 1]) {
+      const num = parseInt(args[speakerIndex + 1], 10);
+      if (!isNaN(num) && num > 0) {
+        options.numSpeakers = num;
+      }
+    }
   }
 
   // Parse output file
@@ -104,9 +109,9 @@ Options:
 
 Transcription Options:
   --no-diarize         Disable speaker identification (default: enabled)
-  --num-speakers <n>   Number of speakers (default: auto-detect)
-  --speaker-names <names>  Comma-separated speaker names
+  --speaker-names <names>  Comma-separated speaker names (auto-sets speaker count)
                            Example: --speaker-names "Alice,Bob,Charlie"
+  --num-speakers <n>   Number of speakers (only used if --speaker-names not provided)
   --no-timestamp       Disable timestamps in output
   --no-audio-events    Disable audio event tagging
 

--- a/src/handlers/slack-interaction-handler.ts
+++ b/src/handlers/slack-interaction-handler.ts
@@ -82,6 +82,28 @@ function createTranscriptionModal(
     blocks.push(
       {
         type: "input",
+        block_id: "speaker_names_block",
+        optional: true,
+        element: {
+          type: "plain_text_input",
+          action_id: "speaker_names_input",
+          placeholder: {
+            type: "plain_text",
+            text: "田中,山田,佐藤",
+          },
+          ...(currentValues?.speakerNames && { initial_value: currentValues.speakerNames }),
+        },
+        label: {
+          type: "plain_text",
+          text: "📝 話者名（カンマ区切り）",
+        },
+        hint: {
+          type: "plain_text",
+          text: "入力すると話者数は自動で設定されます",
+        },
+      },
+      {
+        type: "input",
         block_id: "num_speakers_block",
         optional: true,
         element: {
@@ -98,25 +120,7 @@ function createTranscriptionModal(
         },
         label: {
           type: "plain_text",
-          text: "🔢 話者数",
-        },
-      },
-      {
-        type: "input",
-        block_id: "speaker_names_block",
-        optional: true,
-        element: {
-          type: "plain_text_input",
-          action_id: "speaker_names_input",
-          placeholder: {
-            type: "plain_text",
-            text: "田中,山田,佐藤",
-          },
-          ...(currentValues?.speakerNames && { initial_value: currentValues.speakerNames }),
-        },
-        label: {
-          type: "plain_text",
-          text: "📝 話者名（カンマ区切り）",
+          text: "🔢 話者数（話者名未入力時のみ使用）",
         },
       }
     );
@@ -256,7 +260,7 @@ export function createTranscriptionButtonBlocks() {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: "*ファイルから文字起こし*\nファイルを添付して `@bot` にメンションしてください\n\n*オプション（任意）*\n• `--no-diarize` : 話者分離OFF（1人の場合に推奨）\n• `--num-speakers 3` : 話者数を指定\n• `--speaker-names 田中,山田,佐藤` : 話者名を指定(話者数と揃える)\n• `--no-timestamp` : タイムスタンプ非表示\n• `--no-summarize` : 要約をスキップ\n\n例: `@bot --num-speakers 3 --speaker-names 田中,山田,佐藤`",
+        text: "*ファイルから文字起こし*\nファイルを添付して `@bot` にメンションしてください\n\n*オプション（任意）*\n• `--no-diarize` : 話者分離OFF（1人の場合に推奨）\n• `--speaker-names 田中,山田,佐藤` : 話者名を指定（話者数は自動設定）\n• `--num-speakers 3` : 話者数のみ指定（話者名が不明な場合）\n• `--no-timestamp` : タイムスタンプ非表示\n• `--no-summarize` : 要約をスキップ\n\n例: `@bot --speaker-names 田中,山田,佐藤`",
       },
     },
   ];
@@ -301,13 +305,20 @@ function parseModalValues(values: Record<string, Record<string, { value?: string
   const tagAudioEvents = getSelectValue("audio_events_block", "audio_events_select") !== "false";
   const summarize = getSelectValue("summarize_block", "summarize_select") !== "false";
 
-  const numSpeakersStr = getSelectValue("num_speakers_block", "num_speakers_select");
-  const numSpeakers = numSpeakersStr ? parseInt(numSpeakersStr, 10) : 2;
-
+  // Parse speaker names first
   const speakerNamesStr = getInputValue("speaker_names_block", "speaker_names_input");
   const speakerNames = speakerNamesStr
     ? speakerNamesStr.split(/[,，]/).map((s) => s.trim()).filter(Boolean)
     : undefined;
+
+  // Determine numSpeakers: speakerNames takes priority if provided
+  let numSpeakers: number;
+  if (speakerNames && speakerNames.length > 0) {
+    numSpeakers = speakerNames.length;
+  } else {
+    const numSpeakersStr = getSelectValue("num_speakers_block", "num_speakers_select");
+    numSpeakers = numSpeakersStr ? parseInt(numSpeakersStr, 10) : 2;
+  }
 
   const url = getInputValue("url_block", "url_input") || null;
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -11,19 +11,7 @@ export const parseTranscriptionOptions = (
 ): TranscriptionOptions => {
   const diarize = !text.includes("--no-diarize");
 
-  // Parse num-speakers from command, or use default of 2 when diarize is enabled
-  let numSpeakers: number | undefined;
-  if (diarize) {
-    const numSpeakersMatch = text.match(/--num-speakers\s+(\d+)/);
-    if (numSpeakersMatch) {
-      const parsed = parseInt(numSpeakersMatch[1], 10);
-      numSpeakers = (parsed >= 1 && parsed <= 32) ? parsed : 2;
-    } else {
-      numSpeakers = 2; // Default to 2 speakers when diarize is true
-    }
-  }
-
-  // Parse speaker names (supports both quoted and unquoted format)
+  // Parse speaker names first (supports both quoted and unquoted format)
   let speakerNames: string[] | undefined;
   const namesMatch = text.match(
     /--speaker-names\s+(?:"([^"]+)"|([^-]+?)(?:\s+--|\s*$))/,
@@ -31,7 +19,25 @@ export const parseTranscriptionOptions = (
   if (namesMatch) {
     const names = namesMatch[1] || namesMatch[2];
     // Split by both full-width and half-width comma
-    speakerNames = names.trim().split(/[,，]/).map((name) => name.trim());
+    speakerNames = names.trim().split(/[,，]/).map((name) => name.trim()).filter(Boolean);
+  }
+
+  // Determine numSpeakers: speakerNames takes priority if provided
+  let numSpeakers: number | undefined;
+  if (diarize) {
+    if (speakerNames && speakerNames.length > 0) {
+      // If speaker names are provided, use their count as numSpeakers
+      numSpeakers = speakerNames.length;
+    } else {
+      // Otherwise, parse from command or use default of 2
+      const numSpeakersMatch = text.match(/--num-speakers\s+(\d+)/);
+      if (numSpeakersMatch) {
+        const parsed = parseInt(numSpeakersMatch[1], 10);
+        numSpeakers = (parsed >= 1 && parsed <= 32) ? parsed : 2;
+      } else {
+        numSpeakers = 2; // Default to 2 speakers when diarize is true
+      }
+    }
   }
 
   return {


### PR DESCRIPTION
## Summary
- `--speaker-names` が指定された場合、その数を自動的に `numSpeakers` として使用
- ユーザーは話者名と話者数を別々に指定する必要がなくなり、設定の矛盾を防止
- Slack フォームのUIを改善（話者名入力欄を先に配置、ヒント追加）

## 変更内容
| 変更前 | 変更後 |
|--------|--------|
| `--speaker-names` と `--num-speakers` を別々に指定 | `--speaker-names` を指定すれば話者数は自動設定 |
| 両者の不一致時はGeminiの推測に任せる | 構造的に矛盾が発生しない |

## Test plan
- [ ] CLI: `--speaker-names "Alice,Bob,Charlie"` で `numSpeakers=3` が設定されることを確認
- [ ] CLI: `--num-speakers 4` のみ指定時は従来通り動作することを確認
- [ ] Slack: モーダルで話者名を入力すると話者数が自動設定されることを確認
- [ ] Slack: ヘルプメッセージが更新されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 話者名をカンマ区切りで直接入力できるようになりました。
  * 話者名を指定すると、スピーカー数が自動的に設定されるようになりました。

* **改善**
  * CLIとUIのスピーカー設定インターフェースを統一しました。
  * UIモーダルで話者名入力フィールドを新たに追加し、スピーカー数選択をドロップダウンに変更しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->