### PR TITLE
feat: AI要約をコードブロックで表示

### DIFF
--- a/src/adapters/platform-adapter.ts
+++ b/src/adapters/platform-adapter.ts
@@ -64,7 +64,7 @@ export class SlackAdapter implements PlatformAdapter {
   }
 
   async sendSummary(summary: string): Promise<void> {
-    const summaryMessage = `📝 要約\n${summary}`;
+    const summaryMessage = `📝 要約\n\`\`\`\n${summary}\n\`\`\``;
     await sendSlackMessage(this.channelId, summaryMessage, this.threadTimestamp);
   }
 
@@ -111,7 +111,7 @@ export class DiscordAdapter implements PlatformAdapter {
 
   async sendSummary(summary: string): Promise<void> {
     const channelId = this.interaction.channel?.id || "";
-    const summaryMessage = `📝 要約\n${summary}`;
+    const summaryMessage = `📝 要約\n\`\`\`\n${summary}\n\`\`\``;
     await sendDiscordMessage(channelId, summaryMessage);
   }
 


### PR DESCRIPTION
## Summary
- Slack・DiscordのAI要約メッセージをコードブロック(```)で囲んで表示するように変更
- 要約テキストの視認性を向上

## Test plan
- [ ] Slack で文字起こし→要約がコードブロックで表示されること
- [ ] Discord で文字起こし→要約がコードブロックで表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change to outgoing Slack/Discord summary messages; no data handling or workflow logic is modified.
> 
> **Overview**
> AI summary messages sent via `SlackAdapter.sendSummary` and `DiscordAdapter.sendSummary` are now wrapped in triple-backtick code blocks, improving readability/formatting in both platforms.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81a417e13fc0f1839c3c4b574acba5ed49ca0751. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * Slack と Discord チャネルでサマリー表示をコードブロック形式に変更し、可読性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->