### PR TITLE
feat: Vimeoレビューページの文字起こしに対応

### DIFF
--- a/src/adapters/vimeo-review-adapter.ts
+++ b/src/adapters/vimeo-review-adapter.ts
@@ -1,0 +1,35 @@
+import {
+  BaseCloudService,
+  CloudFileMetadata,
+} from "../services/cloud-service.ts";
+import {
+  downloadVimeoReviewAudioToPath,
+  extractVimeoReviewId,
+  getVimeoReviewFileMetadata,
+  isVimeoReviewUrl,
+} from "../clients/vimeo-review.ts";
+
+export class VimeoReviewAdapter extends BaseCloudService {
+  readonly name = "Vimeo Review";
+
+  isValidUrl(url: string): boolean {
+    return isVimeoReviewUrl(url);
+  }
+
+  extractFileId(url: string): string | null {
+    return extractVimeoReviewId(url);
+  }
+
+  async getFileMetadata(reviewUrl: string): Promise<CloudFileMetadata> {
+    return await getVimeoReviewFileMetadata(reviewUrl);
+  }
+
+  async downloadFile(reviewUrl: string, tempPath: string): Promise<boolean> {
+    await downloadVimeoReviewAudioToPath(reviewUrl, tempPath);
+    return true;
+  }
+
+  override getPreferredFileExtension(): string {
+    return "mp3";
+  }
+}

--- a/src/clients/vimeo-review.ts
+++ b/src/clients/vimeo-review.ts
@@ -1,0 +1,215 @@
+import { CloudFileMetadata } from "../services/cloud-service.ts";
+
+const decoder = new TextDecoder();
+
+let ffmpegStatus: "unknown" | "available" | "missing" = "unknown";
+let ffmpegError: string | null = null;
+
+async function ensureFfmpegAvailable(): Promise<void> {
+  if (ffmpegStatus === "available") {
+    return;
+  }
+
+  if (ffmpegStatus === "missing") {
+    throw new Error(ffmpegError ?? "ffmpeg is not available");
+  }
+
+  try {
+    const command = new Deno.Command("ffmpeg", {
+      args: ["-version"],
+      stdout: "piped",
+      stderr: "piped",
+    });
+    const { success, stderr } = await command.output();
+
+    if (!success) {
+      const errorText = decoder.decode(stderr).trim();
+      ffmpegStatus = "missing";
+      ffmpegError =
+        `ffmpeg check failed. Please ensure ffmpeg is installed and accessible in PATH. ${errorText}`
+          .trim();
+      throw new Error(ffmpegError);
+    }
+
+    ffmpegStatus = "available";
+  } catch (error) {
+    ffmpegStatus = "missing";
+    ffmpegError = `ffmpeg is not installed or not accessible. ${
+      error instanceof Error ? error.message : String(error)
+    }`;
+    throw new Error(ffmpegError);
+  }
+}
+
+function sanitizeFilename(filename: string): string {
+  return filename
+    .replace(/[<>:"/\\|?*\x00-\x1F]/g, "_")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 200);
+}
+
+/**
+ * Check if URL is a Vimeo Review URL (new format: /reviews/{uuid}/videos/{id})
+ */
+export function isVimeoReviewUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    const hostname = parsed.hostname.toLowerCase();
+    return hostname.includes("vimeo.com") &&
+      /\/reviews\/[^/]+\/videos\/\d+/.test(parsed.pathname);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Extract video ID from Vimeo Review URL
+ * Returns the full URL since we need it to scrape the page
+ */
+export function extractVimeoReviewId(url: string): string | null {
+  return isVimeoReviewUrl(url) ? url : null;
+}
+
+/**
+ * Fetch the Vimeo player config JSON from a review page
+ * 1. Fetch the review page HTML
+ * 2. Extract the player config URL from the HTML
+ * 3. Fetch the config JSON
+ */
+async function fetchPlayerConfig(
+  reviewUrl: string,
+): Promise<{
+  title: string;
+  duration?: number;
+  hlsUrl: string;
+}> {
+  // Step 1: Fetch the review page HTML
+  const pageResponse = await fetch(reviewUrl);
+  if (!pageResponse.ok) {
+    throw new Error(
+      `Failed to fetch Vimeo review page (status ${pageResponse.status})`,
+    );
+  }
+  const html = await pageResponse.text();
+
+  // Step 2: Extract the player config URL
+  // The HTML contains URLs like: https://player.vimeo.com/video/{id}/config?...
+  // with \u0026 as escaped ampersands
+  const configUrlMatch = html.match(
+    /https:\/\/player\.vimeo\.com\/video\/\d+\/config\?[^"]+/,
+  );
+  if (!configUrlMatch) {
+    throw new Error(
+      "Could not find Vimeo player config URL in review page",
+    );
+  }
+
+  // Unescape \u0026 -> &
+  const configUrl = configUrlMatch[0].replace(/\\u0026/g, "&");
+
+  // Step 3: Fetch the config JSON
+  const configResponse = await fetch(configUrl, {
+    headers: {
+      "Referer": "https://vimeo.com/",
+    },
+  });
+  if (!configResponse.ok) {
+    throw new Error(
+      `Failed to fetch Vimeo player config (status ${configResponse.status})`,
+    );
+  }
+
+  const config = await configResponse.json();
+
+  // Extract video info
+  const title = config?.video?.title || "vimeo_review_video";
+  const duration = config?.video?.duration;
+
+  // Extract HLS URL from config
+  const hlsCdns = config?.request?.files?.hls?.cdns;
+  if (!hlsCdns) {
+    throw new Error("Could not find HLS stream URLs in Vimeo player config");
+  }
+
+  // Pick the default CDN or the first available one
+  const defaultCdn = config?.request?.files?.hls?.default_cdn;
+  const cdnData = hlsCdns[defaultCdn] || Object.values(hlsCdns)[0];
+  const hlsUrl = (cdnData as { url?: string })?.url;
+
+  if (!hlsUrl) {
+    throw new Error("Could not extract HLS URL from Vimeo player config");
+  }
+
+  return { title, duration, hlsUrl };
+}
+
+/**
+ * Get metadata for a Vimeo Review video
+ */
+export async function getVimeoReviewFileMetadata(
+  reviewUrl: string,
+): Promise<CloudFileMetadata> {
+  const { title, duration } = await fetchPlayerConfig(reviewUrl);
+  const sanitizedTitle = sanitizeFilename(title);
+  const filename = `${sanitizedTitle}.mp3`;
+
+  return {
+    id: reviewUrl,
+    filename,
+    mimeType: "audio/mpeg",
+    duration,
+  };
+}
+
+/**
+ * Download audio from a Vimeo Review video using ffmpeg
+ */
+export async function downloadVimeoReviewAudioToPath(
+  reviewUrl: string,
+  outputPath: string,
+): Promise<void> {
+  await ensureFfmpegAvailable();
+
+  const { hlsUrl } = await fetchPlayerConfig(reviewUrl);
+
+  const command = new Deno.Command("ffmpeg", {
+    args: [
+      "-y",
+      "-i",
+      hlsUrl,
+      "-vn",
+      "-acodec",
+      "libmp3lame",
+      "-b:a",
+      "192k",
+      "-loglevel",
+      "error",
+      outputPath,
+    ],
+    stdout: "piped",
+    stderr: "piped",
+  });
+
+  const { success, stderr } = await command.output();
+  if (!success) {
+    const errorText = decoder.decode(stderr).trim();
+    throw new Error(
+      `Failed to download Vimeo Review audio: ${errorText || "Unknown error"}`,
+    );
+  }
+
+  // Verify output file
+  try {
+    const stat = await Deno.stat(outputPath);
+    if (!stat.isFile || stat.size === 0) {
+      throw new Error("Output file is empty after ffmpeg conversion");
+    }
+  } catch (error) {
+    throw new Error(
+      `Vimeo Review audio output verification failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}

--- a/src/clients/vimeo-review.ts
+++ b/src/clients/vimeo-review.ts
@@ -71,8 +71,18 @@ export function extractVimeoReviewId(url: string): string | null {
   return isVimeoReviewUrl(url) ? url : null;
 }
 
+// Cache player config to avoid fetching twice (metadata + download)
+const playerConfigCache = new Map<string, {
+  title: string;
+  duration?: number;
+  hlsUrl: string;
+  cachedAt: number;
+}>();
+
+const CONFIG_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
 /**
- * Fetch the Vimeo player config JSON from a review page
+ * Fetch the Vimeo player config JSON from a review page (with caching)
  * 1. Fetch the review page HTML
  * 2. Extract the player config URL from the HTML
  * 3. Fetch the config JSON
@@ -84,6 +94,11 @@ async function fetchPlayerConfig(
   duration?: number;
   hlsUrl: string;
 }> {
+  // Return cached config if available and fresh
+  const cached = playerConfigCache.get(reviewUrl);
+  if (cached && (Date.now() - cached.cachedAt) < CONFIG_CACHE_TTL_MS) {
+    return { title: cached.title, duration: cached.duration, hlsUrl: cached.hlsUrl };
+  }
   // Step 1: Fetch the review page HTML
   const pageResponse = await fetch(reviewUrl);
   if (!pageResponse.ok) {
@@ -141,7 +156,17 @@ async function fetchPlayerConfig(
     throw new Error("Could not extract HLS URL from Vimeo player config");
   }
 
+  // Cache the result
+  playerConfigCache.set(reviewUrl, { title, duration, hlsUrl, cachedAt: Date.now() });
+
   return { title, duration, hlsUrl };
+}
+
+/**
+ * Clear cached config for a URL (called after download completes)
+ */
+function clearConfigCache(reviewUrl: string): void {
+  playerConfigCache.delete(reviewUrl);
 }
 
 /**
@@ -191,11 +216,18 @@ export async function downloadVimeoReviewAudioToPath(
     stderr: "piped",
   });
 
-  const { success, stderr } = await command.output();
+  const { success, stdout, stderr } = await command.output();
+  const stderrText = decoder.decode(stderr).trim();
+  const stdoutText = decoder.decode(stdout).trim();
+
+  // Clear cache after download attempt
+  clearConfigCache(reviewUrl);
+
   if (!success) {
-    const errorText = decoder.decode(stderr).trim();
+    console.error("[VimeoReview] ffmpeg failed:", stderrText);
+    console.error("[VimeoReview] ffmpeg stdout:", stdoutText);
     throw new Error(
-      `Failed to download Vimeo Review audio: ${errorText || "Unknown error"}`,
+      `Failed to download Vimeo Review audio: ${stderrText || "Unknown error"}`,
     );
   }
 
@@ -203,9 +235,16 @@ export async function downloadVimeoReviewAudioToPath(
   try {
     const stat = await Deno.stat(outputPath);
     if (!stat.isFile || stat.size === 0) {
+      console.error("[VimeoReview] Output file missing or empty after successful ffmpeg");
+      console.error("[VimeoReview] ffmpeg stderr:", stderrText);
       throw new Error("Output file is empty after ffmpeg conversion");
     }
   } catch (error) {
+    if (error instanceof Error && error.message.includes("Output file is empty")) {
+      throw error;
+    }
+    console.error("[VimeoReview] stat failed for:", outputPath);
+    console.error("[VimeoReview] ffmpeg stderr:", stderrText);
     throw new Error(
       `Vimeo Review audio output verification failed: ${
         error instanceof Error ? error.message : String(error)

--- a/src/clients/youtube.ts
+++ b/src/clients/youtube.ts
@@ -163,6 +163,10 @@ export function isYouTubeUrl(url: string): boolean {
     const parsed = new URL(url);
     const hostname = parsed.hostname.toLowerCase();
     // Support YouTube and other yt-dlp compatible sites like Loom, Vimeo
+    // Exclude Vimeo review URLs (/reviews/{uuid}/videos/{id}) - handled by VimeoReviewAdapter
+    if (hostname.includes("vimeo.com") && /\/reviews\/[^/]+\/videos\/\d+/.test(parsed.pathname)) {
+      return false;
+    }
     return hostname.includes("youtube.com") ||
            hostname === "youtu.be" ||
            hostname.endsWith("youtube-nocookie.com") ||

--- a/src/services/cloud-service-manager.ts
+++ b/src/services/cloud-service-manager.ts
@@ -10,6 +10,7 @@ import { DropboxAdapter } from "../adapters/dropbox-adapter.ts";
 import { YouTubeAdapter } from "../adapters/youtube-adapter.ts";
 import { HlsAdapter } from "../adapters/hls-adapter.ts";
 import { UtageAdapter } from "../adapters/utage-adapter.ts";
+import { VimeoReviewAdapter } from "../adapters/vimeo-review-adapter.ts";
 import { getErrorMessage } from "../utils/errors.ts";
 
 export class CloudServiceManager {
@@ -29,6 +30,7 @@ export class CloudServiceManager {
 
     // Future services can be registered here:
     cloudServiceRegistry.register(new DropboxAdapter());
+    cloudServiceRegistry.register(new VimeoReviewAdapter());
     cloudServiceRegistry.register(new YouTubeAdapter());
     cloudServiceRegistry.register(new UtageAdapter());
     cloudServiceRegistry.register(new HlsAdapter());

--- a/src/services/file-processor.ts
+++ b/src/services/file-processor.ts
@@ -54,8 +54,10 @@ export async function processCloudFile(
     adapter: PlatformAdapter;
   }
 ): Promise<ProcessingResult> {
+  let tempPath: string | undefined;
   try {
     const result = await cloudServiceManager.downloadFromUrl(url);
+    tempPath = result.tempPath;
 
     if (!result.success) {
       return { success: false, error: result.error };
@@ -86,8 +88,18 @@ export async function processCloudFile(
       error: getErrorMessage(error)
     };
   } finally {
-    // Cleanup is handled by cloudServiceManager
-    await cloudServiceManager.cleanup();
+    // Clean up only this request's temp file, not all tracked files
+    // cloudServiceManager is a singleton, so cleanup() would delete
+    // temp files from other concurrent requests
+    if (tempPath) {
+      try {
+        await Deno.remove(tempPath).catch(() => {});
+        const dirPath = tempPath.substring(0, tempPath.lastIndexOf("/"));
+        await Deno.remove(dirPath, { recursive: true }).catch(() => {});
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- 新形式のVimeoレビューURL (`/reviews/{uuid}/videos/{id}`) からの文字起こしに対応
- yt-dlpが新形式に未対応のため、ページHTMLからプレイヤー設定を直接取得しHLSストリームをFFmpegでダウンロードする方式で実装
- 既存のVimeo通常URLのyt-dlp経由の処理には影響なし

## Changes
- `src/clients/vimeo-review.ts` — レビューページのスクレイピング & HLSダウンロードクライアント
- `src/adapters/vimeo-review-adapter.ts` — VimeoReviewAdapter（既存パターンに準拠）
- `src/services/cloud-service-manager.ts` — アダプター登録（YouTubeAdapterの前に配置）
- `src/clients/youtube.ts` — レビューURLをYouTubeクライアントから除外

## Test plan
- [ ] Vimeoレビューページ URL で文字起こしが成功すること
- [ ] 通常のVimeo URL が従来通りyt-dlp経由で処理されること
- [ ] YouTube/Loom等の既存URLに影響がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Vimeo ReviewからMP3でオーディオを抽出・ダウンロードできる機能を追加しました。
  * 新しいVimeo Reviewソースがアプリのクラウドサービス一覧に登録されました。
* **バグ修正**
  * Vimeo Review用URLが誤ってYouTubeとして扱われる問題を回避しました。
  * ダウンロード後の一時ファイルをリクエスト単位で確実に削除するように改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->