### PR TITLE
feat(youtube): yt-dlpにYOUTUBE_PROXY経由のproxy指定を追加

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -75,6 +75,12 @@ if [ -n "${YOUTUBE_COOKIES_BASE64:-}" ]; then
   echo "✅ Including YouTube cookies in deployment"
 fi
 
+# Add optional YouTube proxy if set
+if [ -n "${YOUTUBE_PROXY:-}" ]; then
+  ENV_VARS="$ENV_VARS,YOUTUBE_PROXY=$YOUTUBE_PROXY"
+  echo "✅ Including YouTube proxy in deployment"
+fi
+
 # Deploy with all environment variables and CPU optimization
 gcloud run deploy scribe-bot \
   --project="$GCP_PROJECT_ID" \

--- a/src/clients/youtube.ts
+++ b/src/clients/youtube.ts
@@ -158,6 +158,10 @@ function getCookieArgs(cookiesFilePath: string | null): string[] {
   return args;
 }
 
+function getProxyArgs(): string[] {
+  return config.youtubeProxy ? ["--proxy", config.youtubeProxy] : [];
+}
+
 export function isYouTubeUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
@@ -225,6 +229,7 @@ export async function getYouTubeFileMetadata(
   // Create cookies file if needed
   const cookiesInfo = await createCookiesFileIfNeeded();
   const cookieArgs = getCookieArgs(cookiesInfo.path);
+  const proxyArgs = getProxyArgs();
 
   try {
     const command = new Deno.Command("yt-dlp", {
@@ -233,6 +238,7 @@ export async function getYouTubeFileMetadata(
         "--skip-download",
         "--no-warnings",
         ...cookieArgs,
+        ...proxyArgs,
         url,
       ],
       stdout: "piped",
@@ -303,6 +309,7 @@ export async function downloadYouTubeAudioToPath(
   // Create cookies file if needed
   const cookiesInfo = await createCookiesFileIfNeeded();
   const cookieArgs = getCookieArgs(cookiesInfo.path);
+  const proxyArgs = getProxyArgs();
 
   try {
     // Try multiple format selection strategies for better compatibility
@@ -319,6 +326,7 @@ export async function downloadYouTubeAudioToPath(
         "--no-playlist",
         "--ignore-errors", // Continue even if some formats fail
         ...cookieArgs,
+        ...proxyArgs,
         "-o",
         outputPath,
         url,

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -26,6 +26,7 @@ interface Config {
   // YouTube (optional)
   youtubeCookies?: string; // Path to cookies file (for local/container usage)
   youtubeCookiesBase64?: string; // Base64-encoded cookies file content (for Cloud Run)
+  youtubeProxy?: string; // Proxy URL for yt-dlp (e.g. http://user:pass@host:port)
 }
 
 function getEnvOrThrow(key: string, defaultValue?: string): string {
@@ -63,6 +64,7 @@ export const config: Config = {
   // YouTube (optional)
   youtubeCookies: getOptionalEnv("YOUTUBE_COOKIES"),
   youtubeCookiesBase64: getOptionalEnv("YOUTUBE_COOKIES_BASE64"),
+  youtubeProxy: getOptionalEnv("YOUTUBE_PROXY"),
 };
 
 export default config;


### PR DESCRIPTION
## Summary

- Cloud Run のデータセンター IP が YouTube の bot 検知に引っかかり `Sign in to confirm you're not a bot` エラーで文字起こしが失敗する問題を、residential proxy 経由で回避
- `YOUTUBE_PROXY` 環境変数に proxy URL (`http://user:pass@host:port`) を設定すると、yt-dlp のメタデータ取得・音声ダウンロード両方の呼び出しに `--proxy` が注入される
- proxy 未設定時は従来どおりの挙動（オプショナル）

## Background

YouTube が 2024 年以降 bot 検知を強化し、Cloud Run のような data center IP 帯域からのアクセスは cookies を設定しても弾かれるケースが増加。根本原因が IP レピュテーションなので、residential proxy 経由にするのが最も確実な対策。今回は IPRoyal の pay-as-you-go ($7.35/GB) を採用。

## Changes

- `src/core/config.ts`: `youtubeProxy` オプションを追加
- `src/clients/youtube.ts`: `getProxyArgs()` を追加し、`getYouTubeFileMetadata` と `downloadYouTubeAudioToPath` の yt-dlp 引数に反映
- `scripts/deploy.sh`: `.env` の `YOUTUBE_PROXY` を Cloud Run の環境変数に渡す

## Verification

- ローカルで `yt-dlp --proxy ... --dump-json https://youtu.be/YWnczsR1tJ8` が bot 検知エラーなく JSON を返すことを確認済み
- proxy 経由での residential IP 取得 (`curl -x ... ipv4.icanhazip.com`) も確認済み

## Test plan

- [ ] `.env` に `YOUTUBE_PROXY` を設定
- [ ] `./scripts/deploy.sh` でデプロイ（`✅ Including YouTube proxy in deployment` が出ることを確認）
- [ ] Slack から以前失敗した YouTube URL (`Yc67tLMzHME` 等) を投げて文字起こしが完了することを確認
- [ ] cookies のみで通っていた動画でも引き続き通ることを確認（互換性）

## Notes

- IPRoyal の認証情報はシークレットとして扱う（.env に保持、Cloud Run は `--set-env-vars` 経由で渡る）
- 消費帯域目安: 音声のみ約 1 MB/分、1 GB で ~15 時間分の動画
- 期限: pay-as-you-go は購入後 30 日で失効。常用するなら subscription への移行を検討

🤖 Generated with [Claude Code](https://claude.com/claude-code)