### PR TITLE
feat(slack): 要約・エラーメッセージをBlock Kit化

### DIFF
--- a/src/adapters/platform-adapter.ts
+++ b/src/adapters/platform-adapter.ts
@@ -3,17 +3,26 @@ import { formatOptionsText } from "../services/file-processor.ts";
 import { sendSlackMessage, uploadTranscriptToSlack, downloadSlackFileToPath } from "../clients/slack.ts";
 import { editInteractionReply, sendDiscordMessage, uploadTranscriptToDiscord, downloadDiscordFile } from "../clients/discord.ts";
 import { getUsageMessage } from "../utils/messages.ts";
+import {
+  buildSummaryBlocks,
+  buildErrorBlocks,
+  summaryFallbackText,
+} from "../utils/slack-blocks.ts";
 // @ts-ignore: Types are provided in the deployment environment
 import { APIInteraction } from "discord-api-types/v10";
 
+export interface SummaryContext {
+  filename?: string;
+  options?: TranscriptionOptions;
+}
+
 export interface PlatformAdapter {
   sendStatusMessage(message: string): Promise<void>;
-  sendErrorMessage(error: string): Promise<void>;
-  sendSuccessMessage(filename: string): Promise<void>;
+  sendErrorMessage(error: string, hint?: string): Promise<void>;
   sendUsageMessage(): Promise<void>;
   formatProcessingMessage(filename: string, options: TranscriptionOptions): string;
   uploadTranscript(transcript: string, filename?: string): Promise<void>;
-  sendSummary(summary: string): Promise<void>;
+  sendSummary(summary: string, context?: SummaryContext): Promise<void>;
   downloadFile(fileURL: string, filePath: string): Promise<void>;
 }
 
@@ -35,19 +44,13 @@ export class SlackAdapter implements PlatformAdapter {
     await sendSlackMessage(this.channelId, message, this.threadTimestamp);
   }
 
-  async sendErrorMessage(error: string): Promise<void> {
+  async sendErrorMessage(error: string, hint?: string): Promise<void> {
+    const blocks = buildErrorBlocks(error, hint);
     await sendSlackMessage(
       this.channelId,
-      `❌ ${error}`,
-      this.threadTimestamp
-    );
-  }
-
-  async sendSuccessMessage(filename: string): Promise<void> {
-    await sendSlackMessage(
-      this.channelId,
-      `✅ "${filename}" の文字起こしが完了しました！`,
-      this.threadTimestamp
+      `⚠️ ${error}`,
+      this.threadTimestamp,
+      blocks,
     );
   }
 
@@ -63,9 +66,18 @@ export class SlackAdapter implements PlatformAdapter {
     await uploadTranscriptToSlack(transcript, this.channelId, this.threadTimestamp);
   }
 
-  async sendSummary(summary: string): Promise<void> {
-    const summaryMessage = `📝 要約\n\`\`\`\n${summary}\n\`\`\``;
-    await sendSlackMessage(this.channelId, summaryMessage, this.threadTimestamp);
+  async sendSummary(summary: string, context?: SummaryContext): Promise<void> {
+    const blocks = buildSummaryBlocks({
+      summary,
+      filename: context?.filename,
+      options: context?.options,
+    });
+    await sendSlackMessage(
+      this.channelId,
+      summaryFallbackText(context?.filename),
+      this.threadTimestamp,
+      blocks,
+    );
   }
 
   async downloadFile(fileURL: string, filePath: string): Promise<void> {
@@ -82,18 +94,9 @@ export class DiscordAdapter implements PlatformAdapter {
     await editInteractionReply(this.interaction.token, message);
   }
 
-  async sendErrorMessage(error: string): Promise<void> {
-    await editInteractionReply(
-      this.interaction.token,
-      `❌ ${error}`
-    );
-  }
-
-  async sendSuccessMessage(filename: string): Promise<void> {
-    await editInteractionReply(
-      this.interaction.token,
-      `✅ "${filename}" の文字起こしが完了しました！`
-    );
+  async sendErrorMessage(error: string, hint?: string): Promise<void> {
+    const message = hint ? `⚠️ ${error}\n${hint}` : `⚠️ ${error}`;
+    await editInteractionReply(this.interaction.token, message);
   }
 
   async sendUsageMessage(): Promise<void> {
@@ -109,10 +112,12 @@ export class DiscordAdapter implements PlatformAdapter {
     await uploadTranscriptToDiscord(transcript, channelId);
   }
 
-  async sendSummary(summary: string): Promise<void> {
+  async sendSummary(summary: string, context?: SummaryContext): Promise<void> {
     const channelId = this.interaction.channel?.id || "";
-    const summaryMessage = `📝 要約\n\`\`\`\n${summary}\n\`\`\``;
-    await sendDiscordMessage(channelId, summaryMessage);
+    const header = context?.filename
+      ? `📝 **"${context.filename}" の要約**`
+      : "📝 **文字起こし要約**";
+    await sendDiscordMessage(channelId, `${header}\n\n${summary}`);
   }
 
   async downloadFile(fileURL: string, filePath: string): Promise<void> {

--- a/src/core/scribe.ts
+++ b/src/core/scribe.ts
@@ -81,7 +81,7 @@ export async function transcribeAudioFile({
       if (options.summarize !== false) {
         try {
           const summary = await summarizeTranscript(finalTranscript);
-          await adapter.sendSummary(summary);
+          await adapter.sendSummary(summary, { filename, options });
         } catch (error) {
           console.error("Failed to generate or send transcript summary:", error);
         }

--- a/src/utils/slack-blocks.ts
+++ b/src/utils/slack-blocks.ts
@@ -1,0 +1,178 @@
+/**
+ * Slack Block Kit builders for bot responses.
+ *
+ * - Summary result: header + section(mrkdwn) + optional context meta.
+ * - Errors: section with alert prefix + optional context hint.
+ *
+ * Slack section text has a 3000-char limit; long summaries are split across
+ * multiple section blocks. Block Kit payloads also cap at 50 blocks, which
+ * is not a concern for short AI summaries.
+ */
+
+import { TranscriptionOptions } from "../core/types.ts";
+import { generateOptionInfo } from "../services/file-processor.ts";
+
+// deno-lint-ignore no-explicit-any
+export type SlackBlock = any;
+
+const SECTION_TEXT_LIMIT = 2900;
+
+/**
+ * Convert Gemini-style Markdown to Slack mrkdwn.
+ * Patterned after launch-management-system's markdownToSlackText.
+ */
+export function markdownToMrkdwn(text: string): string {
+  const lines = text.split("\n");
+  const out: string[] = [];
+  let inCodeBlock = false;
+
+  for (const line of lines) {
+    if (/^```/.test(line)) {
+      inCodeBlock = !inCodeBlock;
+      out.push(line);
+      continue;
+    }
+    if (inCodeBlock) {
+      out.push(line);
+      continue;
+    }
+
+    if (/^---+\s*$/.test(line)) {
+      out.push("━━━━━━━━━━━━━━━");
+      continue;
+    }
+
+    const headerMatch = line.match(/^#{1,6}\s+(.+)$/);
+    if (headerMatch) {
+      out.push(`*${headerMatch[1].trim()}*`);
+      continue;
+    }
+
+    const converted = line
+      .replace(/\*\*(.+?)\*\*/g, "*$1*")
+      .replace(/\[([^\]]+)\]\(([^)]+)\)/g, "<$2|$1>")
+      .replace(/^(\s*)[-*]\s+/, "$1• ");
+
+    out.push(converted);
+  }
+
+  return out.join("\n");
+}
+
+/**
+ * Split long text into chunks under Slack's section-text limit.
+ * Breaks on blank lines when possible to keep paragraphs intact.
+ */
+function splitForSection(text: string, maxLen: number = SECTION_TEXT_LIMIT): string[] {
+  if (text.length <= maxLen) return [text];
+
+  const chunks: string[] = [];
+  const paragraphs = text.split(/\n\n+/);
+  let current = "";
+
+  for (const para of paragraphs) {
+    const candidate = current ? `${current}\n\n${para}` : para;
+    if (candidate.length > maxLen && current) {
+      chunks.push(current);
+      current = para;
+    } else if (candidate.length > maxLen) {
+      // single paragraph too long — hard-split by lines
+      const lines = para.split("\n");
+      for (const line of lines) {
+        const next = current ? `${current}\n${line}` : line;
+        if (next.length > maxLen && current) {
+          chunks.push(current);
+          current = line;
+        } else {
+          current = next;
+        }
+      }
+    } else {
+      current = candidate;
+    }
+  }
+
+  if (current) chunks.push(current);
+  return chunks;
+}
+
+function section(mrkdwn: string): SlackBlock {
+  return {
+    type: "section",
+    text: { type: "mrkdwn", text: mrkdwn },
+  };
+}
+
+function context(mrkdwn: string): SlackBlock {
+  return {
+    type: "context",
+    elements: [{ type: "mrkdwn", text: mrkdwn }],
+  };
+}
+
+function header(text: string): SlackBlock {
+  return {
+    type: "header",
+    text: { type: "plain_text", text, emoji: true },
+  };
+}
+
+function divider(): SlackBlock {
+  return { type: "divider" };
+}
+
+/**
+ * Build the summary result message as Block Kit.
+ */
+export function buildSummaryBlocks({
+  summary,
+  filename,
+  options,
+}: {
+  summary: string;
+  filename?: string;
+  options?: TranscriptionOptions;
+}): SlackBlock[] {
+  const blocks: SlackBlock[] = [header("📝 文字起こし要約")];
+
+  if (filename) {
+    blocks.push(context(`*ファイル:* ${filename}`));
+  }
+
+  blocks.push(divider());
+
+  const mrkdwn = markdownToMrkdwn(summary);
+  for (const chunk of splitForSection(mrkdwn)) {
+    blocks.push(section(chunk));
+  }
+
+  if (options) {
+    const info = generateOptionInfo(options);
+    if (info.length > 0) {
+      blocks.push(context(`⚙️ ${info.join(" / ")}`));
+    }
+  }
+
+  return blocks;
+}
+
+/**
+ * Build an error message as Block Kit.
+ */
+export function buildErrorBlocks(message: string, hint?: string): SlackBlock[] {
+  const blocks: SlackBlock[] = [section(`⚠️ *エラー*\n${message}`)];
+  if (hint) {
+    blocks.push(context(hint));
+  }
+  return blocks;
+}
+
+/**
+ * Plain-text fallback used in the `text` field alongside `blocks`.
+ * Shown in notifications and when Block Kit can't be rendered.
+ */
+export function summaryFallbackText(filename?: string): string {
+  return filename
+    ? `📝 "${filename}" の要約`
+    : "📝 文字起こし要約";
+}


### PR DESCRIPTION
## Summary
- Gemini要約のMarkdownをSlack mrkdwnに変換し、header/divider/section/context で構造化表示
- エラー応答も section + context に統一（`hint` 追加で対処方法を併記可能）
- Discord 側はファイル名付きヘッダに整形。Block Kit は Slack のみ
- 未使用だった `sendSuccessMessage` を削除

## 背景
- 要約メッセージがコードブロック (```) に包まれており、Gemini のマークダウン（見出し/太字/リスト）が素のまま表示されていた
- 要約は文字数的に Block Kit の 3000字/section 制限に収まるため、従来撤廃していた Block 化を復活

## 主な変更
- `src/utils/slack-blocks.ts` 新設 — `markdownToMrkdwn()` / `buildSummaryBlocks()` / `buildErrorBlocks()` / `summaryFallbackText()`。3000字超は section 分割
- `src/adapters/platform-adapter.ts` — `sendSummary(summary, context?)` / `sendErrorMessage(error, hint?)` にシグネチャ拡張
- `src/core/scribe.ts` — 要約送信時に `filename` と `options` を渡してメタ情報を context block に反映

## Test plan
- [ ] Slack で音声ファイルを添付 → 要約が header/section/context 構造で表示される
- [ ] `--speaker-names` 付きで実行 → ⚙️ に話者情報が出る
- [ ] `--no-summarize` で実行 → 要約メッセージが出ない
- [ ] サポートされていない URL → ⚠️ エラー section が表示される
- [ ] 長文要約（3000字超）→ 複数 section に分割されて欠落なく表示される
- [ ] Discord 側も ファイル名ヘッダ付きで要約が届く

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * エラーメッセージにヒント情報の表示に対応
  * サマリーにファイル名と設定情報を含むコンテキスト情報を追加

* **改善**
  * Slackでのエラーとサマリー表示をブロック形式で構造化
  * Discord上でのエラーメッセージを条件付きで詳細に表示
  * ファイル名が利用可能な場合、コンテキスト対応ヘッダーを表示

<!-- end of auto-generated comment: release notes by coderabbit.ai -->