### PR TITLE
feat(cli): document supported URL sources, add list-sources subcommand

### DIFF
--- a/src/adapters/dropbox-adapter.ts
+++ b/src/adapters/dropbox-adapter.ts
@@ -12,6 +12,12 @@ import {
 
 export class DropboxAdapter extends BaseCloudService {
   readonly name = "Dropbox";
+  readonly description =
+    "Dropbox 共有リンク（ファイルまたはフォルダ）。dl=1 への自動変換に対応。";
+  readonly urlExamples = [
+    "https://www.dropbox.com/s/<HASH>/<FILE>?dl=0",
+    "https://www.dropbox.com/scl/fi/<HASH>/<FILE>?dl=0",
+  ];
 
   isValidUrl(url: string): boolean {
     return isDropboxUrl(url);

--- a/src/adapters/google-drive-adapter.ts
+++ b/src/adapters/google-drive-adapter.ts
@@ -12,6 +12,11 @@ import {
 
 export class GoogleDriveAdapter extends BaseCloudService {
   readonly name = "Google Drive";
+  readonly description =
+    "Google Drive 上の音声・動画ファイル。共有リンクが必要（最大 20GB）。";
+  readonly urlExamples = [
+    "https://drive.google.com/file/d/<FILE_ID>/view",
+  ];
 
   isValidUrl(url: string): boolean {
     return isGoogleDriveUrl(url);

--- a/src/adapters/hls-adapter.ts
+++ b/src/adapters/hls-adapter.ts
@@ -8,6 +8,11 @@ import {
 
 export class HlsAdapter extends BaseCloudService {
   readonly name = "HLS";
+  readonly description =
+    "HLS 動画ストリーム（.m3u8 マニフェスト）。ffmpeg で音声を抽出。";
+  readonly urlExamples = [
+    "https://example.com/path/to/playlist.m3u8",
+  ];
 
   isValidUrl(url: string): boolean {
     return isHlsUrl(url);

--- a/src/adapters/utage-adapter.ts
+++ b/src/adapters/utage-adapter.ts
@@ -7,6 +7,11 @@ import {
 
 export class UtageAdapter extends BaseCloudService {
   readonly name = "Utage";
+  readonly description =
+    "Utage 配信プラットフォームの動画。ページから埋め込み動画を抽出してダウンロード。";
+  readonly urlExamples = [
+    "https://<your-tenant>.utage-system.com/video/<VIDEO_ID>",
+  ];
 
   isValidUrl(url: string): boolean {
     return isUtageUrl(url);

--- a/src/adapters/vimeo-review-adapter.ts
+++ b/src/adapters/vimeo-review-adapter.ts
@@ -11,6 +11,11 @@ import {
 
 export class VimeoReviewAdapter extends BaseCloudService {
   readonly name = "Vimeo Review";
+  readonly description =
+    "Vimeo の Review ページ（プライベート共有用 URL）。通常の Vimeo は YouTube/Loom/Vimeo アダプタで処理。";
+  readonly urlExamples = [
+    "https://vimeo.com/<VIDEO_ID>/<REVIEW_HASH>",
+  ];
 
   isValidUrl(url: string): boolean {
     return isVimeoReviewUrl(url);

--- a/src/adapters/youtube-adapter.ts
+++ b/src/adapters/youtube-adapter.ts
@@ -8,6 +8,14 @@ import {
 
 export class YouTubeAdapter extends BaseCloudService {
   readonly name = "YouTube/Loom/Vimeo";
+  readonly description =
+    "YouTube・Loom・通常の Vimeo 動画。yt-dlp で音声を取得。メンバー限定動画は YOUTUBE_COOKIES_BASE64 が必要。";
+  readonly urlExamples = [
+    "https://www.youtube.com/watch?v=<VIDEO_ID>",
+    "https://youtu.be/<VIDEO_ID>",
+    "https://www.loom.com/share/<SHARE_ID>",
+    "https://vimeo.com/<VIDEO_ID>",
+  ];
 
   isValidUrl(url: string): boolean {
     return isYouTubeUrl(url);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { transcribeFile } from "./core/transcribe-core.ts";
 import { TranscriptionOptions } from "./core/types.ts";
 import { createTranscriptionHeader } from "./utils/utils.ts";
 import { cloudServiceManager } from "./services/cloud-service-manager.ts";
+import { cloudServiceRegistry } from "./services/cloud-service.ts";
 import { runInit } from "./init.ts";
 
 function userConfigEnvPath(): string {
@@ -140,6 +141,30 @@ function parseArgs(): { filePath: string; options: CliOptions } {
 }
 
 /**
+ * Build a "Supported sources" section by reading from the registry.
+ * Adapters that set `description` are listed; URL examples come from
+ * `urlExamples`. New adapters appear automatically without touching cli.ts.
+ */
+function buildSupportedSourcesSection(): string {
+  const services = cloudServiceRegistry.getAllServices()
+    .filter((s) => s.description);
+  if (services.length === 0) return "";
+
+  const lines = ["Supported URL sources:"];
+  for (const s of services) {
+    lines.push(`  ${s.name}`);
+    lines.push(`    ${s.description}`);
+    if (s.urlExamples?.length) {
+      for (const ex of s.urlExamples) {
+        lines.push(`    e.g. ${ex}`);
+      }
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+/**
  * Print help message
  */
 function printHelp(): void {
@@ -148,12 +173,15 @@ ElevenLabs Transcription CLI
 
 Usage: scribe [options] <file-or-url>
        scribe init
+       scribe list-sources
 
 Subcommands:
   init                 Interactively set API keys (saved to ~/.config/scribe/.env)
+  list-sources         Print supported URL sources and exit
 
 Arguments:
-  <file-or-url>        Path to audio/video file, or supported URL (Google Drive/Dropbox/YouTube)
+  <file-or-url>        Path to a local audio/video file, or a URL from one of
+                       the supported sources (run \`scribe list-sources\` to see all).
 
 Options:
   -h, --help           Show this help message
@@ -164,30 +192,44 @@ Options:
 
 Transcription Options:
   --no-diarize         Disable speaker identification (default: enabled)
-  --speaker-names <names>  Comma-separated speaker names (auto-sets speaker count)
+  --speaker-names <names>  Comma-separated speaker names (auto-sets speaker count).
+                           Names are matched to speaker_N labels via Gemini.
                            Example: --speaker-names "Alice,Bob,Charlie"
   --num-speakers <n>   Number of speakers (only used if --speaker-names not provided)
   --no-timestamp       Disable timestamps in output
   --no-audio-events    Disable audio event tagging
 
 Examples:
-  # Basic transcription to stdout
-  deno run --allow-all src/cli.ts audio.mp3
+  # Local file → transcripts/<name>_<timestamp>.txt
+  scribe meeting.mp4
 
-  # Save to file with speaker names
-  deno run --allow-all src/cli.ts -o transcript.txt --speaker-names "Alice,Bob" meeting.mp4
+  # Save to specific path with speaker names (Gemini maps speaker_N → real name)
+  scribe interview.mp4 --speaker-names "Alice,Bob" -o ./out.txt
 
-  # JSON output without timestamps
-  deno run --allow-all src/cli.ts -f json --no-timestamp audio.m4a
+  # Stdout (no file save), JSON, no timestamps
+  scribe audio.m4a --no-save -f json --no-timestamp
 
-  # Disable speaker diarization
-  deno run --allow-all src/cli.ts --no-diarize recording.wav
+  # Single speaker — disable diarization for cleaner output
+  scribe monologue.wav --no-diarize
 
-  # Transcribe from a supported URL (Dropbox / Google Drive / YouTube)
-  deno run --allow-all src/cli.ts "https://www.youtube.com/watch?v=xxxxxxx" --speaker-names "Alice,Bob"
+  # YouTube / Loom / Google Drive / Dropbox / Vimeo / Utage / HLS URL
+  scribe 'https://youtu.be/<VIDEO_ID>' --speaker-names "Host,Guest"
 
-Note: Video files (mp4, mkv, mov, etc.) will be automatically converted to audio before transcription.
+${buildSupportedSourcesSection()}Note: Video files (mp4, mkv, mov, etc.) are automatically converted to audio
+      before transcription via ffmpeg.
 `);
+}
+
+/**
+ * Print supported sources for `scribe list-sources`.
+ */
+function printSources(): void {
+  const section = buildSupportedSourcesSection();
+  if (section) {
+    console.log(section.trimEnd());
+  } else {
+    console.log("No URL sources are registered.");
+  }
 }
 
 /**
@@ -196,6 +238,11 @@ Note: Video files (mp4, mkv, mov, etc.) will be automatically converted to audio
 async function main() {
   if (Deno.args[0] === "init") {
     await runInit(userConfigEnvPath());
+    return;
+  }
+
+  if (Deno.args[0] === "list-sources") {
+    printSources();
     return;
   }
 

--- a/src/services/cloud-service.ts
+++ b/src/services/cloud-service.ts
@@ -25,6 +25,18 @@ export interface CloudService {
   readonly name: string;
 
   /**
+   * One-line human description shown in `scribe --help` and `scribe list-sources`.
+   * Optional — adapters that don't set this won't appear in the docs section.
+   */
+  readonly description?: string;
+
+  /**
+   * Example URLs accepted by this service (1〜3 件)。
+   * Optional — purely for documentation in --help / list-sources.
+   */
+  readonly urlExamples?: readonly string[];
+
+  /**
    * Check if URL belongs to this service
    */
   isValidUrl(url: string): boolean;
@@ -108,7 +120,6 @@ export class CloudServiceRegistry {
    */
   register(service: CloudService): void {
     this.services.set(service.name.toLowerCase(), service);
-    console.log(`Registered cloud service: ${service.name}`);
   }
 
   /**


### PR DESCRIPTION
## Summary

- AI（`transcribe-interview` skill 経由 / 直接 Bash）が `scribe` を呼ぶ前提で、`--help` から「実際に何の URL ソースに対応しているか」を発見できるようにする
- `scribe list-sources` サブコマンドを追加（スクリプト・AI 向けの discovery）
- "Supported URL sources" セクションは registry から動的構築 — 今後新しい adapter を追加する時も cli.ts に手を入れる必要なし

## Changes

- `CloudService` インターフェースに optional の `description` / `urlExamples` を追加
- 6 つの adapter に注記：Google Drive / Dropbox / Vimeo Review / YouTube/Loom/Vimeo / Utage / HLS
- `printHelp()` で `cloudServiceRegistry.getAllServices()` を反復して supported sources を埋め込み
- Examples を `deno run --allow-all src/cli.ts ...`（CLI 配布前の名残）→ `scribe ...` に修正
- 起動時の "Registered cloud service: \<name\>" ログを削除（`--help` 出力に漏れていた）

## Before / After

\`\`\`
Before: <file-or-url>  Path to audio/video file, or supported URL (Google Drive/Dropbox/YouTube)
                       ↑ Vimeo Review / Utage / HLS / Loom が抜けている

After:  <file-or-url>  Path to a local audio/video file, or a URL from one of
                       the supported sources (run `scribe list-sources` to see all).
        + Supported URL sources セクション（6 サービス全て、URL 例付き）
\`\`\`

## Test plan

- [x] `deno check` 通る
- [x] `deno compile` 通る
- [x] `scribe --help` で 6 サービス全て一覧表示
- [x] `scribe list-sources` サブコマンドが正しい一覧を出す
- [x] `scribe init` / 通常の transcription path は変更なし（既存テスト済み挙動）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * `list-sources` コマンドを追加。サポートされているURL形式と各サービスの説明を確認できるようになりました。

* **改善**
  * 複数のクラウドサービスに説明とURL例を追加し、ヘルプ情報の充実度を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->