### PR TITLE
feat(slack): パスワード入力欄を追加して Vimeo パスワード動画に対応

### DIFF
--- a/src/adapters/youtube-adapter.ts
+++ b/src/adapters/youtube-adapter.ts
@@ -1,4 +1,4 @@
-import { BaseCloudService, CloudFileMetadata } from "../services/cloud-service.ts";
+import { BaseCloudService, CloudDownloadOptions, CloudFileMetadata } from "../services/cloud-service.ts";
 import {
   extractYouTubeVideoId,
   getYouTubeFileMetadata,
@@ -9,7 +9,7 @@ import {
 export class YouTubeAdapter extends BaseCloudService {
   readonly name = "YouTube/Loom/Vimeo";
   readonly description =
-    "YouTube・Loom・通常の Vimeo 動画。yt-dlp で音声を取得。メンバー限定動画は YOUTUBE_COOKIES_BASE64 が必要。";
+    "YouTube・Loom・通常の Vimeo 動画。yt-dlp で音声を取得。メンバー限定動画は YOUTUBE_COOKIES_BASE64 が必要。パスワード付き Vimeo は modal でパスワードを入力。";
   readonly urlExamples = [
     "https://www.youtube.com/watch?v=<VIDEO_ID>",
     "https://youtu.be/<VIDEO_ID>",
@@ -25,12 +25,12 @@ export class YouTubeAdapter extends BaseCloudService {
     return extractYouTubeVideoId(url);
   }
 
-  async getFileMetadata(videoId: string): Promise<CloudFileMetadata> {
-    return await getYouTubeFileMetadata(videoId);
+  async getFileMetadata(videoId: string, opts?: CloudDownloadOptions): Promise<CloudFileMetadata> {
+    return await getYouTubeFileMetadata(videoId, { password: opts?.password });
   }
 
-  async downloadFile(videoId: string, tempPath: string): Promise<boolean> {
-    await downloadYouTubeAudioToPath(videoId, tempPath);
+  async downloadFile(videoId: string, tempPath: string, opts?: CloudDownloadOptions): Promise<boolean> {
+    await downloadYouTubeAudioToPath(videoId, tempPath, { password: opts?.password });
     return true;
   }
 

--- a/src/clients/youtube.ts
+++ b/src/clients/youtube.ts
@@ -163,6 +163,10 @@ function getProxyArgs(): string[] {
   return config.youtubeProxy ? ["--proxy", config.youtubeProxy] : [];
 }
 
+function getPasswordArgs(password?: string): string[] {
+  return password ? ["--video-password", password] : [];
+}
+
 // Errors that typically resolve on retry (bot detection on the proxy IP,
 // transient rate limits). Permanent errors like "Video unavailable" or
 // "Private video" are not listed — retrying those wastes time and bandwidth.
@@ -265,6 +269,7 @@ export function extractYouTubeVideoId(url: string): string | null {
 
 export async function getYouTubeFileMetadata(
   videoId: string,
+  opts?: { password?: string },
 ): Promise<CloudFileMetadata> {
   await ensureYtDlpAvailable();
   const url = createYouTubeWatchUrl(videoId);
@@ -273,6 +278,7 @@ export async function getYouTubeFileMetadata(
   const cookiesInfo = await createCookiesFileIfNeeded();
   const cookieArgs = getCookieArgs(cookiesInfo.path);
   const proxyArgs = getProxyArgs();
+  const passwordArgs = getPasswordArgs(opts?.password);
 
   try {
     const { success, stdout, stderr } = await runYtDlp([
@@ -281,6 +287,7 @@ export async function getYouTubeFileMetadata(
       "--no-warnings",
       ...cookieArgs,
       ...proxyArgs,
+      ...passwordArgs,
       url,
     ]);
 
@@ -339,6 +346,7 @@ export async function getYouTubeFileMetadata(
 export async function downloadYouTubeAudioToPath(
   videoId: string,
   outputPath: string,
+  opts?: { password?: string },
 ): Promise<void> {
   await ensureYtDlpAvailable();
   const url = createYouTubeWatchUrl(videoId);
@@ -347,6 +355,7 @@ export async function downloadYouTubeAudioToPath(
   const cookiesInfo = await createCookiesFileIfNeeded();
   const cookieArgs = getCookieArgs(cookiesInfo.path);
   const proxyArgs = getProxyArgs();
+  const passwordArgs = getPasswordArgs(opts?.password);
 
   try {
     // Try multiple format selection strategies for better compatibility
@@ -363,6 +372,7 @@ export async function downloadYouTubeAudioToPath(
       "--ignore-errors", // Continue even if some formats fail
       ...cookieArgs,
       ...proxyArgs,
+      ...passwordArgs,
       "-o",
       outputPath,
       url,

--- a/src/handlers/slack-interaction-handler.ts
+++ b/src/handlers/slack-interaction-handler.ts
@@ -21,6 +21,7 @@ function createTranscriptionModal(
   diarizeEnabled: boolean = true,
   currentValues?: {
     url?: string;
+    password?: string;
     numSpeakers?: string;
     speakerNames?: string;
     timestamp?: string;
@@ -49,6 +50,28 @@ function createTranscriptionModal(
       hint: {
         type: "plain_text",
         text: "対応: Google Drive, Dropbox, Loom, Vimeo, Utage（公開設定が必要）",
+      },
+    },
+    {
+      type: "input",
+      block_id: "password_block",
+      optional: true,
+      element: {
+        type: "plain_text_input",
+        action_id: "password_input",
+        placeholder: {
+          type: "plain_text",
+          text: "（任意）パスワードが必要な動画の場合のみ入力",
+        },
+        ...(currentValues?.password && { initial_value: currentValues.password }),
+      },
+      label: {
+        type: "plain_text",
+        text: "🔒 動画パスワード",
+      },
+      hint: {
+        type: "plain_text",
+        text: "現在パスワード保護に対応しているのは Vimeo のみです。",
       },
     },
     {
@@ -325,6 +348,7 @@ async function handleButtonClick(payload: {
 function parseModalValues(values: Record<string, Record<string, { value?: string; selected_option?: { value: string } }>>): {
   options: TranscriptionOptions;
   url: string | null;
+  password: string | null;
 } {
   const getSelectValue = (blockId: string, actionId: string): string | undefined => {
     return values[blockId]?.[actionId]?.selected_option?.value;
@@ -355,6 +379,7 @@ function parseModalValues(values: Record<string, Record<string, { value?: string
   }
 
   const url = getInputValue("url_block", "url_input") || null;
+  const password = getInputValue("password_block", "password_input")?.trim() || null;
 
   return {
     options: {
@@ -366,6 +391,7 @@ function parseModalValues(values: Record<string, Record<string, { value?: string
       summarize,
     },
     url,
+    password,
   };
 }
 
@@ -382,7 +408,7 @@ async function handleModalSubmission(payload: {
   user: { id: string };
 }) {
   const { channelId, threadTs } = JSON.parse(payload.view.private_metadata);
-  const { options, url } = parseModalValues(payload.view.state.values);
+  const { options, url, password } = parseModalValues(payload.view.state.values);
 
   if (!url) {
     await sendSlackMessage(
@@ -417,7 +443,7 @@ async function handleModalSubmission(payload: {
   });
 
   // Process in background
-  processor.processTextInput(url, options)
+  processor.processTextInput(url, options, password ? { password } : undefined)
     .catch(console.error)
     .finally(() => processor.cleanup());
 }
@@ -454,6 +480,7 @@ export async function handleSlackInteractions(req: Request): Promise<Response> {
       // Extract current values to preserve them
       const currentValues = {
         url: values.url_block?.url_input?.value,
+        password: values.password_block?.password_input?.value,
         numSpeakers: values.num_speakers_block?.num_speakers_select?.selected_option?.value,
         speakerNames: values.speaker_names_block?.speaker_names_input?.value,
         timestamp: values.timestamp_block?.timestamp_select?.selected_option?.value,

--- a/src/services/cloud-service-manager.ts
+++ b/src/services/cloud-service-manager.ts
@@ -3,7 +3,7 @@
  * Currently supports Google Drive, easily extensible for Dropbox, OneDrive, etc.
  */
 
-import { CloudService, CloudDownloadResult, cloudServiceRegistry } from "./cloud-service.ts";
+import { CloudDownloadOptions, CloudService, CloudDownloadResult, cloudServiceRegistry } from "./cloud-service.ts";
 import { GoogleDriveAdapter } from "../adapters/google-drive-adapter.ts";
 import { TempFileManager } from "./temp-file-manager.ts";
 import { DropboxAdapter } from "../adapters/dropbox-adapter.ts";
@@ -67,7 +67,7 @@ export class CloudServiceManager {
   /**
    * Download file from any supported cloud service
    */
-  async downloadFromUrl(url: string): Promise<CloudDownloadResult> {
+  async downloadFromUrl(url: string, opts?: CloudDownloadOptions): Promise<CloudDownloadResult> {
     const service = cloudServiceRegistry.getServiceForUrl(url);
 
     if (!service) {
@@ -87,7 +87,7 @@ export class CloudServiceManager {
 
     try {
       // Get metadata first to determine file extension
-      const metadata = await service.getFileMetadata(fileId);
+      const metadata = await service.getFileMetadata(fileId, opts);
 
       // Determine extension from metadata filename or mimeType
       let extension = "tmp";
@@ -108,7 +108,7 @@ export class CloudServiceManager {
       );
 
       // Download file
-      const downloaded = await service.downloadFile(fileId, tempPath);
+      const downloaded = await service.downloadFile(fileId, tempPath, opts);
 
       if (!downloaded) {
         // File was skipped (non-media)

--- a/src/services/cloud-service.ts
+++ b/src/services/cloud-service.ts
@@ -11,6 +11,10 @@ export interface CloudFileMetadata {
   duration?: number;
 }
 
+export interface CloudDownloadOptions {
+  password?: string;
+}
+
 export interface CloudDownloadResult {
   success: boolean;
   metadata?: CloudFileMetadata;
@@ -49,12 +53,12 @@ export interface CloudService {
   /**
    * Get file metadata
    */
-  getFileMetadata(fileId: string): Promise<CloudFileMetadata>;
+  getFileMetadata(fileId: string, opts?: CloudDownloadOptions): Promise<CloudFileMetadata>;
 
   /**
    * Download file to temporary path
    */
-  downloadFile(fileId: string, tempPath: string): Promise<boolean>;
+  downloadFile(fileId: string, tempPath: string, opts?: CloudDownloadOptions): Promise<boolean>;
 
   /**
    * Check if file is a media file that should be transcribed
@@ -74,8 +78,8 @@ export abstract class BaseCloudService implements CloudService {
   abstract readonly name: string;
   abstract isValidUrl(url: string): boolean;
   abstract extractFileId(url: string): string | null;
-  abstract getFileMetadata(fileId: string): Promise<CloudFileMetadata>;
-  abstract downloadFile(fileId: string, tempPath: string): Promise<boolean>;
+  abstract getFileMetadata(fileId: string, opts?: CloudDownloadOptions): Promise<CloudFileMetadata>;
+  abstract downloadFile(fileId: string, tempPath: string, opts?: CloudDownloadOptions): Promise<boolean>;
 
   /**
    * Common media file check

--- a/src/services/file-processor.ts
+++ b/src/services/file-processor.ts
@@ -53,11 +53,12 @@ export async function processCloudFile(
     userId: string;
     transcriptionOptions: TranscriptionOptions;
     adapter: PlatformAdapter;
+    password?: string;
   }
 ): Promise<ProcessingResult> {
   let tempPath: string | undefined;
   try {
-    const result = await cloudServiceManager.downloadFromUrl(url);
+    const result = await cloudServiceManager.downloadFromUrl(url, { password: options.password });
     tempPath = result.tempPath;
 
     if (!result.success) {

--- a/src/services/transcription-processor.ts
+++ b/src/services/transcription-processor.ts
@@ -44,6 +44,7 @@ export class TranscriptionProcessor {
   async processTextInput(
     text: string,
     options: TranscriptionOptions,
+    downloadOpts?: { password?: string },
   ): Promise<void> {
     const { cloudUrls } = extractMediaInfo(text);
 
@@ -68,7 +69,7 @@ export class TranscriptionProcessor {
       }
 
       try {
-        const metadata = await service.getFileMetadata(fileId);
+        const metadata = await service.getFileMetadata(fileId, downloadOpts);
         if (service.isMediaFile(metadata.mimeType)) {
           mediaUrls.push(url);
         } else {
@@ -106,7 +107,7 @@ export class TranscriptionProcessor {
 
     // Process only media file URLs
     for (const url of mediaUrls) {
-      await this.processCloudUrl(url, options);
+      await this.processCloudUrl(url, options, downloadOpts);
     }
   }
 
@@ -116,6 +117,7 @@ export class TranscriptionProcessor {
   async processCloudUrl(
     url: string,
     options: TranscriptionOptions,
+    downloadOpts?: { password?: string },
   ): Promise<void> {
     try {
       // Get metadata first to send status message with filename
@@ -135,7 +137,7 @@ export class TranscriptionProcessor {
       }
 
       // Get metadata first to check if it's a media file
-      const metadata = await service.getFileMetadata(fileId);
+      const metadata = await service.getFileMetadata(fileId, downloadOpts);
 
       // Check if file is a media file before sending status message
       if (!service.isMediaFile(metadata.mimeType)) {
@@ -155,6 +157,7 @@ export class TranscriptionProcessor {
         userId: this.context.userId,
         transcriptionOptions: options,
         adapter: this.adapter,
+        password: downloadOpts?.password,
       });
 
       if (!result.success) {


### PR DESCRIPTION
## Summary
- Slack の文字起こしモーダルに optional なパスワード入力欄を追加
- yt-dlp の `--video-password` 経由でパスワード保護 Vimeo 動画を取得できるようにした
- `CloudDownloadOptions` を CloudService 層に通し、将来他サービスのパスワード対応も同じ経路で拡張できる構造に

## 実装メモ
- 通常の `vimeo.com/{id}` URL は既に `YouTubeAdapter` 経由で yt-dlp が処理しているため、yt-dlp に `--video-password <PW>` を流すだけでパスワード保護動画に対応できる。
- パスワード未入力時は引数を追加しない (従来動作と完全互換)。
- パスワード非対応の adapter (Google Drive / Dropbox 等) は `opts` を素通りで受け取って無視するだけ。
- diarize 切替時のモーダル再描画でも入力済みパスワードが消えないように `currentValues` に追加。

## 注意点
- Vimeo 側で埋め込み制限・ドメイン制限が掛かっていると、パスワードを通しても `player.vimeo.com/.../config` が 403 を返すケースは突破できない (パスワードではなく権限の問題)。
- パスワードは modal state にだけ保持。`private_metadata` には載せていない。

## Test plan
- [ ] パスワードなしの YouTube/Loom/通常 Vimeo 動画が従来どおり処理できること
- [ ] パスワード付き Vimeo 動画 + 正しいパスワードで文字起こしが完走すること
- [ ] パスワード付き Vimeo 動画 + 誤ったパスワードで yt-dlp のエラーが Slack に返ること
- [ ] モーダルで diarize を切り替えてもパスワード欄の入力値が保持されること
- [ ] Google Drive / Dropbox 等のパスワード非対応サービスに副作用がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * パスワード保護されたビデオに対応しました。Slackの文字起こしモーダルでパスワードを入力することで、保護されたYouTube/Vimeoビデオを文字起こしできるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->