### PR TITLE
fix(vimeo): impersonation 同梱 + タイムアウト時のリトライ

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,10 @@ FROM denoland/deno:latest
 
 # Install ffmpeg for video to audio conversion and yt-dlp for YouTube downloads
 # yt-dlp from apt is outdated; install latest via pip for Loom/Vimeo compatibility
+# curl-cffi enables yt-dlp の impersonation。Vimeo は datacenter IP からの無印リクエストを
+# 黙って絞るため、Chrome ふりをしないと Cloud Run から応答が返らない。
 RUN apt-get update && apt-get install -y ffmpeg python3-pip && rm -rf /var/lib/apt/lists/* \
-    && pip3 install --break-system-packages yt-dlp
+    && pip3 install --break-system-packages yt-dlp curl-cffi
 
 WORKDIR /app
 

--- a/src/clients/youtube.ts
+++ b/src/clients/youtube.ts
@@ -175,6 +175,9 @@ const RETRIABLE_YTDLP_ERROR_PATTERNS: RegExp[] = [
   /confirm you[''’]?re not a bot/i,
   /HTTP Error 429/i,
   /HTTP Error 403/i,
+  /timed out/i,
+  /Unable to download webpage/i,
+  /Connection reset/i,
 ];
 
 function isRetriableYtDlpError(stderrText: string): boolean {


### PR DESCRIPTION
## Summary
- Cloud Run から Vimeo の metadata 取得が timeout で1発失敗する事象の本命対処を2段で実施。
- **本命**: Dockerfile に \`curl-cffi\` を追加し、yt-dlp の impersonation を有効化。
- **保険**: \`RETRIABLE_YTDLP_ERROR_PATTERNS\` に \`timed out\` / \`Unable to download webpage\` / \`Connection reset\` を追加し、一過性の失敗は3回リトライで救う。

## 背景
本番ログ:
\`\`\`
Error: Failed to fetch YouTube metadata: ERROR: [vimeo] 1187769026: Unable to download webpage: timed out
\`\`\`

ローカルで同 URL を叩くとエラーまで到達:
\`\`\`
WARNING: [vimeo] The extractor is attempting impersonation, but no impersonate target is available
ERROR: [vimeo] 1187769026: This video is protected by a password, use the --video-password option
\`\`\`

つまり Vimeo は **datacenter IP の無印リクエストには応答すら返さない**。yt-dlp の Vimeo extractor は curl-cffi (impersonation) があれば Chrome ふりで突破できるので、これを image に同梱する。

## 変更点
- \`Dockerfile\`: \`pip3 install yt-dlp curl-cffi\` に変更
- \`src/clients/youtube.ts\`: retriable パターンに timeout 系を追加 (3回リトライ + バックオフは既存)

## Test plan
- [ ] Cloud Run デプロイ後、パスワード保護 Vimeo が password 入力で文字起こし完走すること
- [ ] パスワードなしの YouTube/Loom/通常 Vimeo 動画が引き続き処理できること
- [ ] 一時的なタイムアウト発生時に3回リトライされ、最終的に成功するなら完走すること
- [ ] yt-dlp ログで "attempting impersonation, but no impersonate target is available" の警告が消えること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * YouTube ダウンロード処理の信頼性が向上しました。接続タイムアウトや「Unable to download webpage」「connection reset」などの一時的なエラー時に自動的に再試行され、失敗が減ります。
* **変更**
  * ビルド時の環境に追加の依存が導入され、一部のリクエスト互換性とダウンロード安定性が改善されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->