### PR TITLE
Fix m4a attachment MIME detection

### DIFF
--- a/src/handlers/discord-handler.ts
+++ b/src/handlers/discord-handler.ts
@@ -163,7 +163,7 @@ function handleMessageCommand(
 
   // Check for attachments
   const audioVideoAttachments = message.attachments?.filter(attachment =>
-    isValidAudioVideoFile(attachment.content_type)
+    isValidAudioVideoFile(attachment.content_type, attachment.filename)
   );
 
   // Check for cloud URLs in message content

--- a/src/services/file-processor.ts
+++ b/src/services/file-processor.ts
@@ -4,6 +4,7 @@ import { transcribeAudioFile } from "../core/scribe.ts";
 import { cloudServiceManager } from "./cloud-service-manager.ts";
 import { PlatformAdapter } from "../adapters/platform-adapter.ts";
 import { getErrorMessage } from "../utils/errors.ts";
+import { isAudioVideoMimeType, resolveMediaMimeType } from "../utils/utils.ts";
 
 export interface FileInfo {
   filename: string;
@@ -40,9 +41,11 @@ export function formatOptionsText(options: TranscriptionOptions): string {
   return optionInfo.length > 0 ? ` (${optionInfo.join(", ")})` : "";
 }
 
-export function isValidAudioVideoFile(mimeType: string | undefined): boolean {
-  if (!mimeType) return false;
-  return mimeType.startsWith("audio/") || mimeType.startsWith("video/");
+export function isValidAudioVideoFile(
+  mimeType: string | undefined,
+  filename?: string,
+): boolean {
+  return isAudioVideoMimeType(resolveMediaMimeType(mimeType, filename));
 }
 
 export async function processCloudFile(
@@ -69,9 +72,14 @@ export async function processCloudFile(
       return { success: false, error: "Failed to get file metadata" };
     }
 
+    const fileType = resolveMediaMimeType(
+      result.metadata.mimeType,
+      result.metadata.filename,
+    ) || result.metadata.mimeType;
+
     await transcribeAudioFile({
       fileURL: `file://${result.tempPath}`,
-      fileType: result.metadata.mimeType,
+      fileType,
       duration: 0,
       channelId: options.channelId,
       timestamp: options.timestamp,

--- a/src/services/transcription-processor.ts
+++ b/src/services/transcription-processor.ts
@@ -12,7 +12,7 @@ import {
   processCloudFile,
 } from "./file-processor.ts";
 import { PlatformAdapter } from "../adapters/platform-adapter.ts";
-import { getFileExtensionFromMime } from "../utils/utils.ts";
+import { getFileExtensionFromMime, resolveMediaMimeType } from "../utils/utils.ts";
 import { cloudServiceManager } from "./cloud-service-manager.ts";
 import { cloudServiceRegistry } from "./cloud-service.ts";
 import { getErrorMessage } from "../utils/errors.ts";
@@ -215,7 +215,7 @@ export class TranscriptionProcessor {
     options: TranscriptionOptions,
   ): Promise<void> {
     for (const attachment of attachments) {
-      if (!isValidAudioVideoFile(attachment.mimeType)) {
+      if (!isValidAudioVideoFile(attachment.mimeType, attachment.filename)) {
         await this.adapter.sendStatusMessage(
           `ファイル "${attachment.filename}" は音声または動画ファイルではありません。`,
         );
@@ -263,7 +263,11 @@ export class TranscriptionProcessor {
       );
 
       // Download file using platform adapter
-      const extension = getFileExtensionFromMime(attachment.mimeType || "");
+      const fileType = resolveMediaMimeType(
+        attachment.mimeType,
+        attachment.filename,
+      ) || "";
+      const extension = getFileExtensionFromMime(fileType);
       tempPath = await this.tempManager.createTempFile("audio", extension);
       await this.adapter.downloadFile(attachment.url, tempPath);
 
@@ -271,7 +275,7 @@ export class TranscriptionProcessor {
       const fileURL = `file://${tempPath}`;
       await transcribeAudioFile({
         fileURL,
-        fileType: attachment.mimeType || "",
+        fileType,
         duration: attachment.duration || 0,
         channelId: this.context.channelId,
         timestamp: this.context.timestamp,

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -50,24 +50,92 @@ export const parseTranscriptionOptions = (
   };
 };
 
+const mimeToExt: Record<string, string> = {
+  "audio/mpeg": "mp3",
+  "audio/mp3": "mp3",
+  "audio/wav": "wav",
+  "audio/wave": "wav",
+  "audio/x-wav": "wav",
+  "audio/mp4": "m4a",
+  "audio/m4a": "m4a",
+  "audio/x-m4a": "m4a",
+  "audio/aac": "aac",
+  "audio/ogg": "ogg",
+  "application/ogg": "ogg",
+  "audio/webm": "webm",
+  "video/mp4": "mp4",
+  "video/mpeg": "mpg",
+  "video/quicktime": "mov",
+  "video/x-msvideo": "avi",
+  "video/webm": "webm",
+};
+
+const extToMime: Record<string, string> = {
+  mp3: "audio/mpeg",
+  wav: "audio/wav",
+  m4a: "audio/mp4",
+  aac: "audio/aac",
+  ogg: "audio/ogg",
+  flac: "audio/flac",
+  webm: "video/webm",
+  mp4: "video/mp4",
+  mov: "video/quicktime",
+  avi: "video/x-msvideo",
+  mpg: "video/mpeg",
+  mpeg: "video/mpeg",
+  mkv: "video/x-matroska",
+};
+
+const mimeAliases: Record<string, string> = {
+  "audio/mp3": "audio/mpeg",
+  "audio/wave": "audio/wav",
+  "audio/x-wav": "audio/wav",
+  "audio/m4a": "audio/mp4",
+  "audio/x-m4a": "audio/mp4",
+  "application/ogg": "audio/ogg",
+};
+
+export const normalizeMimeType = (mimeType?: string): string | undefined => {
+  const normalized = mimeType?.split(";")[0]?.trim().toLowerCase();
+  return normalized ? mimeAliases[normalized] || normalized : undefined;
+};
+
+export const getFileExtensionFromFilename = (
+  filename?: string,
+): string | undefined => {
+  const name = filename?.split(/[?#]/)[0]?.trim().toLowerCase();
+  const match = name?.match(/\.([a-z0-9]+)$/);
+  return match?.[1];
+};
+
+export const getMimeTypeFromFilename = (
+  filename?: string,
+): string | undefined => {
+  const extension = getFileExtensionFromFilename(filename);
+  return extension ? extToMime[extension] : undefined;
+};
+
+export const isAudioVideoMimeType = (mimeType?: string): boolean => {
+  const normalized = normalizeMimeType(mimeType);
+  return !!normalized &&
+    (normalized.startsWith("audio/") || normalized.startsWith("video/") ||
+      normalized === "application/ogg");
+};
+
+export const resolveMediaMimeType = (
+  mimeType?: string,
+  filename?: string,
+): string | undefined => {
+  const normalized = normalizeMimeType(mimeType);
+  if (isAudioVideoMimeType(normalized)) {
+    return normalized;
+  }
+  return getMimeTypeFromFilename(filename) || normalized;
+};
+
 export const getFileExtensionFromMime = (mimeType: string): string => {
-  const mimeToExt: Record<string, string> = {
-    "audio/mpeg": "mp3",
-    "audio/mp3": "mp3",
-    "audio/wav": "wav",
-    "audio/wave": "wav",
-    "audio/x-wav": "wav",
-    "audio/mp4": "m4a",
-    "audio/aac": "aac",
-    "audio/ogg": "ogg",
-    "audio/webm": "webm",
-    "video/mp4": "mp4",
-    "video/mpeg": "mpg",
-    "video/quicktime": "mov",
-    "video/x-msvideo": "avi",
-    "video/webm": "webm",
-  };
-  return mimeToExt[mimeType] || mimeType.split("/")[1] || "bin";
+  const normalized = normalizeMimeType(mimeType) || "";
+  return mimeToExt[normalized] || normalized.split("/")[1] || "bin";
 };
 
 export const formatTimestamp = (seconds: number): string => {


### PR DESCRIPTION
## Summary
- Fall back to filename extension when Slack/Discord provide a generic or missing MIME type for attachments
- Normalize common audio MIME aliases such as audio/x-m4a to audio/mp4
- Pass the resolved MIME type through download and transcription paths so temporary files keep the correct extension

## Verification
- deno check --config src/deno.json src/index.ts
- deno eval MIME resolution smoke check for application/octet-stream + sample.m4a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 音声・動画ファイルの検出精度を向上させました。ファイルのMIMEタイプに加えてファイル名も用いた判定により、より正確にメディアファイルを識別できるようになります。文字起こし機能の信頼性が向上しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ele-inc/elevenlabs-transcribe-bot/pull/30?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->